### PR TITLE
Change URL length documentation, to max 17 bytes

### DIFF
--- a/eddystone-url/README.md
+++ b/eddystone-url/README.md
@@ -13,7 +13,7 @@ Byte offset | Field | Description
 0 | Frame Type | Value = `0x10`
 1 | TX Power | Calibrated Tx power at 0 m
 2 | URL Scheme | Encoded Scheme Prefix
-3+ | Encoded URL | Length 0-18
+3+ | Encoded URL | Length 0-17
 
 ### Tx Power Level
 


### PR DESCRIPTION
UriBeacons supported an 18 byte payloads for uri length, but the EddyStone-URL frame type supports 17.

The documentation currently mentions URL length should be in the 0-18 range, implying 18 is inclusive.  Change the docs to say 0-17.
