### PR TITLE
[BeaconScanner.swift] Typo fix

### DIFF
--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSampleSwift/BeaconScanner.swift
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSampleSwift/BeaconScanner.swift
@@ -78,7 +78,7 @@ class BeaconScanner: NSObject, CBCentralManagerDelegate {
 
   func centralManagerDidUpdateState(central: CBCentralManager!)  {
     if central.state == CBCentralManagerState.PoweredOn && self.shouldBeScanning {
-      self.startScanningSynchronized()();
+      self.startScanningSynchronized();
     }
   }
 


### PR DESCRIPTION
Small fix that was causing the project build to fail.