### PR TITLE
Updates to sample iOS Scanner App

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,3 +16,4 @@ Michal Mocny <mmocny@google.com>
 Roy Want <roywant@google.com>
 Giovanni Ortuno <ortuno@google.com>
 Dave Smith <smith@wiresareobsolete.com>
+Christopher Dro <casheghian@gmail.com>

--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSBeaconScanner.m
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSBeaconScanner.m
@@ -120,10 +120,6 @@ static NSString *const kSeenCacheOnLostTimer = @"on_lost_timer";
     _deviceIDCache[peripheral.identifier] = [ESSBeaconInfo telemetryDataForFrame:serviceData];
   } else if (frameType == kESSEddystoneUIDFrameType) {
     
-    // TODO: This is a temporary placeholder until ESSBeaconScannerDelegate get's fixed.
-    // didUpdateBeacon and didFindBeacon from the ViewController never get triggered.
-    NSLog(@"Found UID Frame %@", serviceData);
-
     CBUUID *eddystoneServiceUUID = [ESSBeaconInfo eddystoneServiceID];
     NSData *eddystoneServiceData = serviceData[eddystoneServiceUUID];
 

--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSBeaconScanner.m
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSBeaconScanner.m
@@ -119,6 +119,11 @@ static NSString *const kSeenCacheOnLostTimer = @"on_lost_timer";
   if (frameType == kESSEddystoneTelemetryFrameType) {
     _deviceIDCache[peripheral.identifier] = [ESSBeaconInfo telemetryDataForFrame:serviceData];
   } else if (frameType == kESSEddystoneUIDFrameType) {
+    
+    // TODO: This is a temporary placeholder until ESSBeaconScannerDelegate get's fixed.
+    // didUpdateBeacon and didFindBeacon from the ViewController never get triggered.
+    NSLog(@"Found UID Frame %@", serviceData);
+
     CBUUID *eddystoneServiceUUID = [ESSBeaconInfo eddystoneServiceID];
     NSData *eddystoneServiceData = serviceData[eddystoneServiceUUID];
 
@@ -172,6 +177,8 @@ static NSString *const kSeenCacheOnLostTimer = @"on_lost_timer";
         }
       }
     }
+  } else if (frameType == kESSEddystoneURLFrameType) {
+    NSLog(@"Found URL Frame %@", serviceData);
   } else {
     NSLog(@"Unsupported frame type (%d) detected. Ignorning.", (int)frameType);
   }

--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSEddystone.h
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSEddystone.h
@@ -22,6 +22,7 @@ typedef NS_ENUM(NSUInteger, ESSBeaconType) {
 typedef NS_ENUM(NSUInteger, ESSFrameType) {
   kESSEddystoneUnknownFrameType = 0,
   kESSEddystoneUIDFrameType = 1,
+  kESSEddystoneURLFrameType = 2,
   kESSEddystoneTelemetryFrameType,
 };
 

--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSEddystone.m
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSEddystone.m
@@ -37,7 +37,8 @@ static const uint8_t kEddystoneTLMFrameTypeID = 0x20;
 typedef struct __attribute__((packed)) {
   uint8_t frameType;
   int8_t  txPower;
-  uint8_t zipBeaconID[18];
+  uint8_t zipBeaconID[16];
+  uint8_t RFU[2];
 } ESSEddystoneUIDFrameFields;
 
 // Test equality, ensuring that nil is equal to itself.
@@ -174,7 +175,7 @@ static inline BOOL IsEqualOrBothNil(id a, id b) {
 
   // Note: Excluding (RFU) Byte Offsets 18 & 19 when creating beaconID
   NSData *beaconIDData = [NSData dataWithBytes:&uidFrame.zipBeaconID
-                                        length:sizeof(uidFrame.zipBeaconID) - 2];
+                                        length:sizeof(uidFrame.zipBeaconID)];
     
   ESSBeaconID *beaconID = [[ESSBeaconID alloc] initWithType:kESSBeaconTypeEddystone
                                                    beaconID:beaconIDData];

--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSEddystone.m
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSEddystone.m
@@ -115,21 +115,20 @@ static inline BOOL IsEqualOrBothNil(id a, id b) {
  */
 + (ESSFrameType)frameTypeForFrame:(NSDictionary *)advFrameList {
   NSData *frameData = advFrameList[[self eddystoneServiceID]];
-
   // It's an Eddystone ADV frame. Now check if it's a UID (ID) or TLM (telemetry) frame.
-  if (frameData) {
-    uint8_t frameType;
-    if ([frameData length] > 1) {
-      frameType = ((uint8_t *)[frameData bytes])[0];
+    if (frameData && [frameData length] > 1) {
+        uint8_t frameType[frameData.length];
+        [frameData getBytes:&frameType length:frameData.length];
 
-      if (frameType == kEddystoneUIDFrameTypeID) {
+      if (frameType[0] == kEddystoneUIDFrameTypeID) {
         return kESSEddystoneUIDFrameType;
-      } else if (frameType == kEddystoneTLMFrameTypeID) {
+      } else if (frameType[0] == kEddystoneURLFrameTypeID) {
+        return kESSEddystoneURLFrameType;
+      } else if (frameType[0] == kEddystoneTLMFrameTypeID) {
         return kESSEddystoneTelemetryFrameType;
       }
     }
-  }
-
+    
   return kESSEddystoneUnknownFrameType;
 }
 

--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSEddystone.m
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSEddystone.m
@@ -37,7 +37,7 @@ static const uint8_t kEddystoneTLMFrameTypeID = 0x20;
 typedef struct __attribute__((packed)) {
   uint8_t frameType;
   int8_t  txPower;
-  uint8_t zipBeaconID[16];
+  uint8_t zipBeaconID[18];
 } ESSEddystoneUIDFrameFields;
 
 // Test equality, ensuring that nil is equal to itself.
@@ -172,8 +172,10 @@ static inline BOOL IsEqualOrBothNil(id a, id b) {
   }
   [UIDFrameData getBytes:&uidFrame length:sizeof(ESSEddystoneUIDFrameFields)];
 
+  // Note: Excluding (RFU) Byte Offsets 18 & 19 when creating beaconID
   NSData *beaconIDData = [NSData dataWithBytes:&uidFrame.zipBeaconID
-                                        length:sizeof(uidFrame.zipBeaconID)];
+                                        length:sizeof(uidFrame.zipBeaconID) - 2];
+    
   ESSBeaconID *beaconID = [[ESSBeaconID alloc] initWithType:kESSBeaconTypeEddystone
                                                    beaconID:beaconIDData];
   if (beaconID == nil) {

--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSEddystone.m
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSEddystone.m
@@ -26,6 +26,7 @@ static NSString *const kEddystoneServiceID = @"FEAA";
  * values. See the Eddystone spec for complete details.
  */
 static const uint8_t kEddystoneUIDFrameTypeID = 0x00;
+static const uint8_t kEddystoneURLFrameTypeID = 0x10;
 static const uint8_t kEddystoneTLMFrameTypeID = 0x20;
 
 // Note that for these Eddystone structures, the endianness of the individual fields is big-endian,

--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSampleSwift/BeaconScanner.swift
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSampleSwift/BeaconScanner.swift
@@ -148,7 +148,9 @@ class BeaconScanner: NSObject, CBCentralManagerDelegate {
                   ]
                 }
             }
-          }
+          } else if eft == BeaconInfo.EddystoneFrameType.URLFrameType {
+            NSLog("Found URL Frame %@", serviceData);
+        }
       } else {
         NSLog("Unable to find service data; can't process Eddystone")
       }

--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSampleSwift/Eddystone.swift
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSampleSwift/Eddystone.swift
@@ -85,11 +85,13 @@ func ==(lhs: BeaconID, rhs: BeaconID) -> Bool {
 class BeaconInfo : NSObject {
 
   static let EddystoneUIDFrameTypeID: UInt8 = 0x00
+  static let EddystoneURLFrameTypeID: UInt8 = 0x10
   static let EddystoneTLMFrameTypeID: UInt8 = 0x20
 
   enum EddystoneFrameType {
     case UnknownFrameType
     case UIDFrameType
+    case URLFrameType
     case TelemetryFrameType
 
     var description: String {
@@ -98,6 +100,8 @@ class BeaconInfo : NSObject {
         return "Unknown Frame Type"
       case .UIDFrameType:
         return "UID Frame"
+      case .URLFrameType:
+        return "URL Frame"
       case .TelemetryFrameType:
         return "TLM Frame"
       }
@@ -128,6 +132,8 @@ class BeaconInfo : NSObject {
 
         if frameBytes[0] == EddystoneUIDFrameTypeID {
           return EddystoneFrameType.UIDFrameType
+        } else if frameBytes[0] == EddystoneURLFrameTypeID {
+          return EddystoneFrameType.URLFrameType
         } else if frameBytes[0] == EddystoneTLMFrameTypeID {
           return EddystoneFrameType.TelemetryFrameType
         }


### PR DESCRIPTION
There was an issue with converting the frameType properly which was causing the Obj-C version to not function properly.

I also added the ability to scan for URL frame types in both Obj-C and Swift with a simple NSLog dump of the serviceData for now.

There is still an issue with the Obj-C version. These delegate actions never get fired off: 
https://github.com/google/eddystone/blob/master/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ViewController.m#L45-L52

Both iOS and Swift versions were tested using a nRF51822.