### PR TITLE
request for comments: Eddystone-KEY frame type

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,3 +16,4 @@ Michal Mocny <mmocny@google.com>
 Roy Want <roywant@google.com>
 Giovanni Ortuno <ortuno@google.com>
 Dave Smith <smith@wiresareobsolete.com>
+Pavol Rusnak <stick@gk2.sk>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The design of Eddystone has been driven by several key goals:
 ## Protocol Specification
 
 The common frame PDU types and the individual service data byte layouts for
-the Eddystone-UID, -URL and -TLM frame formats are documented in the
+the Eddystone-UID, -URL, -TLM and -KEY frame formats are documented in the
 [Eddystone Protocol Specification](protocol-specification.md).
 
 ## Tools and Code Samples

--- a/eddystone-key/README.md
+++ b/eddystone-key/README.md
@@ -1,0 +1,65 @@
+# Eddystone-KEY
+
+The Eddystone-KEY frame broadcasts a security key which can be used in two-factor authentication systems.
+
+When a beacon is placed in a way that it cannot be easily moved or tampered with (e.g. buried in concrete floor of an office), using this beacon in two-factor authentication system can guarantee that a user is physically present at a certain place at a certain time.
+
+## Frame Specification
+
+The KEY frame is encoded in the advertisement as a Service Data block associated with the Eddystone service UUID. The layout is:
+
+Byte offset | Field | Description
+------------|-------|------------
+0 | Frame Type | Value = `0x11`
+1 | ALGOTYPE | Algorithm type
+2 | KEYID[0] | Key identification
+3 | KEYID[1]
+4 | KEY[0] | Key data
+5 | KEY[1]
+6 | KEY[2]
+7 | KEY[3]
+8 | KEY[4]
+9 | KEY[5]
+10 | KEY[6]
+11 | KEY[7]
+12 | KEY[8]
+13 | KEY[9]
+14 | KEY[10]
+15 | KEY[11]
+16 | KEY[12]
+17 | KEY[13]
+18 | KEY[14]
+19 | KEY[15]
+
+All multi-byte values are big-endian.
+
+### Algorithm type
+
+Algorithm type defines what algorithm was used to generate the key broadcasted in the frame.
+
+Decimal | Hex | Algorithm type | Key data encoding
+--------|-----|----------------|------------------
+`0`   | `0x00` | HOTP ([RFC 4226](https://tools.ietf.org/html/rfc4226)) | ASCII string padded with NULL
+`1`   | `0x01` | TOTP ([RFC 6238](https://tools.ietf.org/html/rfc6238)) | ASCII string padded with NULL
+`255` | `0xFF` | custom scheme | application specific binary data
+
+### Key identification
+
+Key identification is an application specific field to distinguish between different keys (or their parts).
+Use `00 00` when the field is not needed in your application.
+
+Possible use cases:
+
+* Beacon might want to transmit more keys. The field is interpreted as the key index.
+* Beacon might want to transmit longer key than 16 bytes. The field is interpreted as the part index.
+
+### Key data
+
+Application specific data to be interpreted as a key. This might be the whole key or its part.
+Encoding depends on a specific application, but it should respect the encoding in the algorithm type table.
+
+## Interleaving with other frames
+
+Similarly to Telemetry [TLM](../eddystone-tlm) frames the KEY frames should be interleaved with an identifying frame type (e.g. Eddystone-UID or Eddystone-URL).
+
+In addition, when TLM frames are broadcasted by the beacon, the `ADV_CNT` and/or `SEC_CNT` values must be used during the computation of counter dependent (e.g. HOTP) or time dependent (e.g. TOTP) keys.

--- a/protocol-specification.md
+++ b/protocol-specification.md
@@ -14,6 +14,7 @@ Frame Type | High-Order 4 bits | Byte Value
 UID | `0000` | `0x00`
 URL | `0001` | `0x10`
 TLM | `0010` | `0x20`
+KEY | `0011` | `0x30`
 
 The four low-order bits are reserved for future use and must be `0000`.
 
@@ -56,3 +57,7 @@ The Eddystone-URL frame forms the backbone of the [Physical Web](http://physical
 ## [Eddystone-TLM](eddystone-tlm)
 
 The Eddystone-TLM frame broadcasts telemetry information about the beacon itself such as battery voltage, device temperature, and counts of broadcast packets.
+
+## [Eddystone-KEY](eddystone-key)
+
+The Eddystone-KEY frame broadcasts a security key which can be used in two-factor authentication systems.


### PR DESCRIPTION
I'd like to propose the following frame type:

The Eddystone-KEY frame broadcasts a security key which can be used in two-factor authentication systems.

When a beacon is placed in a way that it cannot be easily moved or tampered with (e.g. buried in concrete floor of an office), using this beacon in two-factor authentication system can guarantee that a user is physically present at a certain place at a certain time.

See the actual commit for more information.

I will push-force the changes to this branch when needed, so please comment in this thread, not in the actual commit.