### PR TITLE
Addition of mbed Eddystone-URL implementation

### DIFF
--- a/eddystone-url/implementations/README.md
+++ b/eddystone-url/implementations/README.md
@@ -13,3 +13,4 @@ To date, in this directory you will find the following implementations:
 * [Cambridge Silicon Radio CSR1010 (Beacon Development Board)](CSR-1010)
 * [RFduino](RFduino)
 * [Linux (bluez)](linux-url-advertiser)
+* [ARM mbed (Nordic nRF51-dongle, nRF51-DK))](mbed_EddystoneURL_Beacon)

--- a/eddystone-url/implementations/mbed_EddystoneURL_Beacon/BLE_API.lib
+++ b/eddystone-url/implementations/mbed_EddystoneURL_Beacon/BLE_API.lib
@@ -1,0 +1,1 @@
+https://developer.mbed.org/users/roywant/code/BLE_API/#13164356b568

--- a/eddystone-url/implementations/mbed_EddystoneURL_Beacon/ConfigParamsPersistence.h
+++ b/eddystone-url/implementations/mbed_EddystoneURL_Beacon/ConfigParamsPersistence.h
@@ -1,0 +1,53 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __BLE_CONFIG_PARAMS_PERSISTENCE_H__
+#define __BLE_CONFIG_PARAMS_PERSISTENCE_H__
+
+#include "ble/services/EddystoneURLConfigService.h"
+
+/**
+ * Generic API to load the Eddystone-URL configuration parameters from persistent
+ * storage. If persistent storage isn't available, the persistenceSignature
+ * member of params may be left un-initialized to the MAGIC, and this will cause
+ * a reset to default values.
+ *
+ * @param[out] paramsP
+ *                 The parameters to be filled in from persistence storage. This
+                   argument can be NULL if the caller is only interested in
+                   discovering the persistence status of params.
+
+ * @return true if params were loaded from persistent storage and have usefully
+ *         initialized fields.
+ */
+bool loadEddystoneURLConfigParams(EddystoneURLConfigService::Params_t *paramsP);
+
+/**
+ * Generic API to store the Eddystone-URL configuration parameters to persistent
+ * storage. It typically initializes the persistenceSignature member of the
+ * params to the MAGIC value to indicate persistence.
+ *
+ * @note: the save operation may be asynchronous. It may be a short while before
+ * the request takes affect. Reading back saved configParams may not yield
+ * correct behaviour if attempted soon after a store.
+ *
+ * @param[in/out] paramsP
+ *                    The params to be saved; persistenceSignature member gets
+ *                    updated if persistence is successful.
+ */
+void saveEddystoneURLConfigParams(const EddystoneURLConfigService::Params_t *paramsP);
+
+#endif /* #ifndef __BLE_CONFIG_PARAMS_PERSISTENCE_H__*/

--- a/eddystone-url/implementations/mbed_EddystoneURL_Beacon/README.md
+++ b/eddystone-url/implementations/mbed_EddystoneURL_Beacon/README.md
@@ -1,0 +1,21 @@
+# ARM/mbed Eddystone-URL Beacon
+
+## Set up an ARM mbed account and compile for a target platform - just needs a browser
+* Visit the [mbed](https://developer.mbed.org/account/login/?next=/) and create an account, then login.
+* Select the compiler button in the top right hand corner of the web page
+* From the line of buttons at the top select "Import" 
+* Select 'click here' to import from URL
+* Source URL: https://developer.mbed.org/users/roywant/code/mbed_EddystoneURL_Beacon/
+* Import Name: mbed_EddystoneURL_Beacon
+* Select "Import", and the program will appear in your Program Workspace
+* Select your target hardware in the list defined in the page top-right button e.g. Nordic nRF51-Dongle
+* Select "Compile" and when 'success' an mbed_EddystoneURL_Beacon.hex file will appear in your downloads
+* Note: this is the same as if you had copied the files from this directory on GitHub into a new project - 
+although perhaps more up-to-date with the latest changes.
+
+## Program the target mbed hardware e.g. Nordic nRF51-Dongle on Windows, Linux, or Mac
+* Insert nRF51-Dongle into a USB port
+* It will create a filer window, just like plugging in a USB Flash drive
+* Drag the  mbed_EddystoneURL_Beacon.hex file created above into that window. 
+* It will be copied to the target hardware, and then reprogram it. Amazing eh!
+* The hardware will automatically restart, and run the Eddystone-URL Beacon code.

--- a/eddystone-url/implementations/mbed_EddystoneURL_Beacon/main.cpp
+++ b/eddystone-url/implementations/mbed_EddystoneURL_Beacon/main.cpp
@@ -1,0 +1,96 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed.h"
+#include "ble/BLE.h"
+#include "ble/services/EddystoneURLConfigService.h"
+#include "ble/services/DFUService.h"
+#include "ble/services/DeviceInformationService.h"
+#include "ConfigParamsPersistence.h"
+
+BLE ble;
+EddystoneURLConfigService *eddystoneUrlConfig;
+
+/**
+ * Eddystone-URL beacons can operate in two modes: a configuration mode which
+ * allows a user to update settings over a connection; and normal Eddystone URL Beacon mode
+ * which involves advertising a URI. Constructing an object from the EddystoneURLConfigService
+ * sets up advertisements for the configuration mode. It is then up to
+ * the application to switch to the Eddystone-URL beacon mode based on some timeout.
+ *
+ * The following help with this switch.
+ */
+static const int CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS = 30;  // Duration after power-on that config service is available.
+Ticker configAdvertisementTimeoutTicker;
+
+/**
+ * Stop advertising the Eddystone URL Config Service after a delay; and switch to normal Eddystone-URL advertisements.
+ */
+void timeout(void)
+{
+    Gap::GapState_t state;
+    state = ble.getGapState();
+    if (!state.connected) { /* don't switch if we're in a connected state. */
+        configAdvertisementTimeoutTicker.detach(); /* disable the callback from the timeout Ticker. */
+        eddystoneUrlConfig->setupEddystoneURLAdvertisements();
+        ble.startAdvertising();
+    }
+}
+
+/**
+ * Callback triggered upon a disconnection event. Needs to re-enable advertisements.
+ */
+void disconnectionCallback(Gap::Handle_t handle, Gap::DisconnectionReason_t reason)
+{
+    configAdvertisementTimeoutTicker.detach(); /* disable the callback from the timeout Ticker. */
+    eddystoneUrlConfig->setupEddystoneURLAdvertisements();
+    ble.startAdvertising();
+}
+
+int main(void)
+{
+    ble.init();
+    ble.onDisconnection(disconnectionCallback);
+
+    /*
+     * Load parameters from (platform specific) persistent storage. Parameters
+     * can be set to non-default values while the Eddystone-URL beacon is in configuration
+     * mode (within the first 60 seconds of power-up). Thereafter, parameters
+     * get copied out to persistent storage before switching to normal EddystoneURL
+     * operation.
+     */
+    EddystoneURLConfigService::Params_t params;
+    bool fetchedFromPersistentStorage = loadEddystoneURLConfigParams(&params);
+
+    /* Initialize a Eddystone URL Config service providing config params, default URI, and power levels. */
+    static EddystoneURLConfigService::PowerLevels_t defaultAdvPowerLevels = {-20, -4, 0, 10}; // Values for ADV packets related to firmware levels
+    eddystoneUrlConfig= new EddystoneURLConfigService(ble, params, !fetchedFromPersistentStorage, "http://physical-web.org", defaultAdvPowerLevels);
+    if (!eddystoneUrlConfig->configuredSuccessfully()) {
+        error("failed to accommodate URI");
+    }
+    configAdvertisementTimeoutTicker.attach(timeout, CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS);
+
+    // Setup auxiliary services to allow over-the-air firmware updates, etc
+    DFUService dfu(ble);
+    DeviceInformationService deviceInfo(ble, "ARM", "Eddystone-URL", "SN1", "hw-rev1", "fw-rev1", "soft-rev1");
+
+    ble.startAdvertising(); /* Set the whole thing in motion. After this call a GAP central can scan the EddystoneURLConfig
+                             * service. This can then be switched to the normal Eddystone-URL beacon functionality after a timeout. */
+
+    while (true) {
+        ble.waitForEvent();
+    }
+}

--- a/eddystone-url/implementations/mbed_EddystoneURL_Beacon/mbed.bld
+++ b/eddystone-url/implementations/mbed_EddystoneURL_Beacon/mbed.bld
@@ -1,0 +1,1 @@
+http://mbed.org/users/mbed_official/code/mbed/builds/b9ad9a133dc7

--- a/eddystone-url/implementations/mbed_EddystoneURL_Beacon/nRF51822.lib
+++ b/eddystone-url/implementations/mbed_EddystoneURL_Beacon/nRF51822.lib
@@ -1,0 +1,1 @@
+http://mbed.org/teams/Nordic-Semiconductor/code/nRF51822/#ca9c9c2cfc6a

--- a/eddystone-url/implementations/mbed_EddystoneURL_Beacon/nrfConfigParamsPersistence.cpp
+++ b/eddystone-url/implementations/mbed_EddystoneURL_Beacon/nrfConfigParamsPersistence.cpp
@@ -1,0 +1,103 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pstorage.h"
+#include "nrf_error.h"
+#include "ConfigParamsPersistence.h"
+
+/**
+ * Nordic specific structure used to store params persistently.
+ * It extends EddystoneURLConfigService::Params_t with a persistence signature.
+ */
+struct PersistentParams_t {
+    EddystoneURLConfigService::Params_t params;
+    uint32_t                         persistenceSignature; /* This isn't really a parameter, but having the expected
+                                                            * magic value in this field indicates persistence. */
+
+    static const uint32_t MAGIC = 0x1BEAC000;              /* Magic that identifies persistence */
+};
+
+/**
+ * The following is a module-local variable to hold configuration parameters for
+ * short periods during flash access. This is necessary because the pstorage
+ * APIs don't copy in the memory provided as data source. The memory cannot be
+ * freed or reused by the application until this flash access is complete. The
+ * load and store operations in this module initialize persistentParams and then
+ * pass it on to the 'pstorage' APIs.
+ */
+static PersistentParams_t persistentParams;
+
+static pstorage_handle_t pstorageHandle;
+
+/**
+ * Dummy callback handler needed by Nordic's pstorage module. This is called
+ * after every flash access.
+ */
+static void pstorageNotificationCallback(pstorage_handle_t *p_handle,
+                                         uint8_t            op_code,
+                                         uint32_t           result,
+                                         uint8_t           *p_data,
+                                         uint32_t           data_len)
+{
+    /* APP_ERROR_CHECK(result); */
+}
+
+/* Platform-specific implementation for persistence on the nRF5x. Based on the
+ * pstorage module provided by the Nordic SDK. */
+bool loadEddystoneURLConfigParams(EddystoneURLConfigService::Params_t *paramsP)
+{
+    static bool pstorageInitied = false;
+    if (!pstorageInitied) {
+        pstorage_init();
+
+        static pstorage_module_param_t pstorageParams = {
+            .cb          = pstorageNotificationCallback,
+            .block_size  = sizeof(PersistentParams_t),
+            .block_count = 1
+        };
+        pstorage_register(&pstorageParams, &pstorageHandle);
+        pstorageInitied = true;
+    }
+
+    if ((pstorage_load(reinterpret_cast<uint8_t *>(&persistentParams), &pstorageHandle, sizeof(PersistentParams_t), 0) != NRF_SUCCESS) ||
+        (persistentParams.persistenceSignature != PersistentParams_t::MAGIC)) {
+        // On failure zero out and let the service reset to defaults
+        memset(paramsP, 0, sizeof(EddystoneURLConfigService::Params_t));
+        return false;
+    }
+
+    memcpy(paramsP, &persistentParams.params, sizeof(EddystoneURLConfigService::Params_t));
+    return true;
+}
+
+/* Platform-specific implementation for persistence on the nRF5x. Based on the
+ * pstorage module provided by the Nordic SDK. */
+void saveEddystoneURLConfigParams(const EddystoneURLConfigService::Params_t *paramsP)
+{
+    memcpy(&persistentParams.params, paramsP, sizeof(EddystoneURLConfigService::Params_t));
+    if (persistentParams.persistenceSignature != PersistentParams_t::MAGIC) {
+        persistentParams.persistenceSignature = PersistentParams_t::MAGIC;
+        pstorage_store(&pstorageHandle,
+                       reinterpret_cast<uint8_t *>(&persistentParams),
+                       sizeof(PersistentParams_t),
+                       0 /* offset */);
+    } else {
+        pstorage_update(&pstorageHandle,
+                        reinterpret_cast<uint8_t *>(&persistentParams),
+                        sizeof(PersistentParams_t),
+                        0 /* offset */);
+    }
+}


### PR DESCRIPTION
Includes the mbed code directory, and a README on how to build it. The
main README for the implementations directory has also been updated.