### PR TITLE
Objective-C Scan & Log all frame types

### DIFF
--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSBeaconScanner.h
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ESSBeaconScanner.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "ESSEddystone.h"
 
 @class ESSBeaconScanner;
 
@@ -21,13 +22,9 @@
 
 @optional
 
-- (void)beaconScanner:(ESSBeaconScanner *)scanner
-        didFindBeacon:(id)beaconInfo;
-- (void)beaconScanner:(ESSBeaconScanner *)scanner
-        didLoseBeacon:(id)beaconInfo;
-
-- (void)beaconScanner:(ESSBeaconScanner *)scanner
-      didUpdateBeacon:(id)beaconInfo;
+- (void)beaconScanner:(ESSBeaconScanner *)scanner didFindBeacon:(ESSBeaconInfo*)beaconInfo;
+- (void)beaconScanner:(ESSBeaconScanner *)scanner didLoseBeacon:(ESSBeaconInfo*)beaconInfo;
+- (void)beaconScanner:(ESSBeaconScanner *)scanner didUpdateBeacon:(ESSBeaconInfo*)beaconInfo updatedFrame:(ESSFrameType)frameType;
 
 @end
 

--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ViewController.h
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ViewController.h
@@ -14,8 +14,6 @@
 
 #import <UIKit/UIKit.h>
 
-@interface ViewController : UIViewController
-
+@interface BeaconScannerTableViewController : UITableViewController
 
 @end
-

--- a/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ViewController.m
+++ b/tools/ios-eddystone-scanner-sample/EddystoneScannerSample/ViewController.m
@@ -15,6 +15,7 @@
 #import "ViewController.h"
 
 #import "ESSBeaconScanner.h"
+#import "ESSEddystone.h"
 
 @interface ViewController () <ESSBeaconScannerDelegate> {
   ESSBeaconScanner *_scanner;
@@ -42,14 +43,53 @@
   _scanner = nil;
 }
 
-- (void)beaconScanner:(ESSBeaconScanner *)scanner
-        didFindBeacon:(id)beaconInfo {
+/**
+ * Called when an Eddystone is seen for the first time.
+ */
+- (void)beaconScanner:(ESSBeaconScanner *)scanner didFindBeacon:(ESSBeaconInfo *)beaconInfo {
   NSLog(@"I Saw an Eddystone!: %@", beaconInfo);
 }
 
-- (void)beaconScanner:(ESSBeaconScanner *)scanner didUpdateBeacon:(id)beaconInfo {
-  NSLog(@"I Updated an Eddystone!: %@", beaconInfo);
+/**
+ * Called when a previously seen Eddystone is no longer detected.
+ */
+- (void)beaconScanner:(ESSBeaconScanner *)scanner didLoseBeacon:(ESSBeaconInfo *)beaconInfo {
+  NSLog(@"I Lost an Eddystone!: %@", beaconInfo);
 }
 
+/**
+ * Called when an already seen Eddystone is redetected.
+ */
+- (void)beaconScanner:(ESSBeaconScanner *)scanner didUpdateBeacon:(ESSBeaconInfo *)beaconInfo updatedFrame:(ESSFrameType)frameType {
+  //NSLog(@"I Updated an Eddystone!: %@, %lu", beaconInfo, (unsigned long)frameType);
+  
+  // Log out specific beacon frame data.
+  switch (frameType) {
+    case kESSEddystoneUIDFrameType: {
+      // Lookup & log the friendly data for the UID frame.
+      ESSBeaconUID *uidData = [ESSBeaconInfo dataForUIDFrame:beaconInfo.uidFrame];
+      NSLog(@"UID FRAME: txPower: %d idNamespace: %@ idInstance: %@", uidData.txPower, uidData.idNamespace, uidData.idInstance);
+    }
+      break;
+      
+    case kESSEddystoneURLFrameType: {
+      // Lookup & log the friendly data for the UID frame.
+      ESSBeaconURL *urlData = [ESSBeaconInfo dataForURLFrame:beaconInfo.urlFrame];
+      NSLog(@"URL FRAME: txPower: %d urlString: %@", urlData.txPower, urlData.urlString);
+    }
+      break;
+      
+    case kESSEddystoneTLMFrameType: {
+      // Lookup & log the friendly data for the TLM frame.
+      ESSBeaconTLM *tlmData = [ESSBeaconInfo dataForTLMFrame:beaconInfo.tlmFrame];
+      NSLog(@"TLM FRAME: version: %u voltage: %d temperature: %f pduCount: %d uptime: %d", tlmData.version, tlmData.voltage, tlmData.temperature, tlmData.advCount, tlmData.uptime);
+    }
+      break;
+      
+    case kESSEddystoneUnknownFrameType:
+      // Do Nothing!
+      break;
+  }
+}
 
 @end


### PR DESCRIPTION
Update to the Objective-c Eddystone Scanner Example that:
* listening for Eddystone message of all frame type, i.e. UID, URL & TLM 
* helper function to extract the message data of each frame type as needed to model objects