### PR TITLE
Add a settings preference

### DIFF
--- a/tools/eddystone-validator/EddystoneValidator/app/src/main/AndroidManifest.xml
+++ b/tools/eddystone-validator/EddystoneValidator/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
+
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name">
@@ -25,6 +26,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".SettingsActivity"
+            android:label="@string/action_settings" />
+
     </application>
 
 </manifest>

--- a/tools/eddystone-validator/EddystoneValidator/app/src/main/java/com/google/sample/eddystonevalidator/MainActivity.java
+++ b/tools/eddystone-validator/EddystoneValidator/app/src/main/java/com/google/sample/eddystonevalidator/MainActivity.java
@@ -15,7 +15,10 @@
 package com.google.sample.eddystonevalidator;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
 
 /**
  * MainActivity for the Eddystone Validator sample app.
@@ -26,6 +29,25 @@ public class MainActivity extends Activity {
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
+  }
+
+  @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    getMenuInflater().inflate(R.menu.menu_main, menu);
+    return true;
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    int id = item.getItemId();
+
+    if (id == R.id.actionSettings) {
+      Intent intent = new Intent(this, SettingsActivity.class);
+      startActivity(intent);
+      return true;
+    }
+
+    return super.onOptionsItemSelected(item);
   }
 
 }

--- a/tools/eddystone-validator/EddystoneValidator/app/src/main/java/com/google/sample/eddystonevalidator/MainActivityFragment.java
+++ b/tools/eddystone-validator/EddystoneValidator/app/src/main/java/com/google/sample/eddystonevalidator/MainActivityFragment.java
@@ -182,7 +182,7 @@ public class MainActivityFragment extends Fragment {
   public void onResume() {
     super.onResume();
 
-    handler.removeCallbacks(null);
+    handler.removeCallbacksAndMessages(null);
 
     int timeoutMillis =
         sharedPreferences.getInt(SettingsActivity.ON_LOST_TIMEOUT_SECS_KEY, 5) * 1000;

--- a/tools/eddystone-validator/EddystoneValidator/app/src/main/java/com/google/sample/eddystonevalidator/NumberPickerPreference.java
+++ b/tools/eddystone-validator/EddystoneValidator/app/src/main/java/com/google/sample/eddystonevalidator/NumberPickerPreference.java
@@ -1,0 +1,83 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sample.eddystonevalidator;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.preference.DialogPreference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.NumberPicker;
+
+public class NumberPickerPreference  extends DialogPreference {
+  private static final int DEFAULT_VALUE = 5;
+
+  private final int min;
+  private final int max;
+
+  private Integer tunedDefault;
+  private int initialValue;
+  private NumberPicker numberPicker;
+
+  public NumberPickerPreference(Context context, AttributeSet attrs) {
+    super(context, attrs);
+
+    TypedArray numberPickerType = context.obtainStyledAttributes(attrs,
+        R.styleable.NumberPickerPreference, 0, 0);
+    min = numberPickerType.getInt(R.styleable.NumberPickerPreference_min, 0);
+    max = numberPickerType.getInt(R.styleable.NumberPickerPreference_max, 10);
+    numberPickerType.recycle();
+    setDialogLayoutResource(R.layout.numberpicker_dialog);
+  }
+
+  @Override
+  protected void onSetInitialValue(boolean restorePersistedValue, Object defaultValueObject) {
+    Integer defaultValue = (Integer) defaultValueObject;
+    if (restorePersistedValue) {
+      int defaultInt = tunedDefault != null ? tunedDefault : DEFAULT_VALUE;
+      initialValue = this.getPersistedInt(defaultInt);
+    } else {
+      initialValue = defaultValue;
+      persistInt(initialValue);
+    }
+  }
+
+  @Override
+  protected Object onGetDefaultValue(TypedArray a, int index) {
+    tunedDefault = a.getInteger(index, DEFAULT_VALUE);
+    return tunedDefault;
+  }
+
+  @Override
+  public void onBindDialogView(View view) {
+    numberPicker = (NumberPicker) view.findViewById(R.id.numberPicker);
+    numberPicker.setMinValue(min);
+    numberPicker.setMaxValue(max);
+    numberPicker.setValue(initialValue);
+    numberPicker.setWrapSelectorWheel(false);
+    numberPicker.setDescendantFocusability(NumberPicker.FOCUS_BLOCK_DESCENDANTS);
+
+    super.onBindDialogView(view);
+  }
+
+  @Override
+  protected void onDialogClosed(boolean positiveResult) {
+    if (positiveResult) {
+      int value = numberPicker.getValue();
+      initialValue = value;
+      persistInt(value);
+    }
+  }
+}

--- a/tools/eddystone-validator/EddystoneValidator/app/src/main/java/com/google/sample/eddystonevalidator/SettingsActivity.java
+++ b/tools/eddystone-validator/EddystoneValidator/app/src/main/java/com/google/sample/eddystonevalidator/SettingsActivity.java
@@ -1,0 +1,72 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sample.eddystonevalidator;
+
+import android.content.SharedPreferences;
+import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceActivity;
+import android.preference.PreferenceFragment;
+import android.preference.PreferenceManager;
+
+
+public class SettingsActivity extends PreferenceActivity {
+  static final String ON_LOST_TIMEOUT_SECS_KEY = "onLostTimeoutSecs";
+  static final String SHOW_DEBUG_INFO_KEY = "showDebugInfo";
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
+    getFragmentManager().beginTransaction().replace(android.R.id.content,
+        new SettingsFragment()).commit();
+  }
+
+  public static class SettingsFragment extends PreferenceFragment
+      implements OnSharedPreferenceChangeListener {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      addPreferencesFromResource(R.xml.preferences);
+      onSharedPreferenceChanged(getPreferenceScreen().getSharedPreferences(),
+          ON_LOST_TIMEOUT_SECS_KEY);
+    }
+
+    @Override
+    public void onResume() {
+      super.onResume();
+      getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onPause() {
+      super.onPause();
+      getPreferenceScreen().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+      if (key.equals(ON_LOST_TIMEOUT_SECS_KEY)) {
+        Preference onLostPref = findPreference(key);
+        int val = sharedPreferences.getInt(key, 5);
+        String unit = val == 1 ? " second" : " seconds";
+        String summary = String.format("Remove from the list devices that haven't been sighted in "
+            + "%d %s. 0 means never remove.", sharedPreferences.getInt(key, 5), unit);
+        onLostPref.setSummary(summary);
+      }
+    }
+  }
+}

--- a/tools/eddystone-validator/EddystoneValidator/app/src/main/res/layout/numberpicker_dialog.xml
+++ b/tools/eddystone-validator/EddystoneValidator/app/src/main/res/layout/numberpicker_dialog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <NumberPicker
+        android:id="@+id/numberPicker"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+
+</LinearLayout>

--- a/tools/eddystone-validator/EddystoneValidator/app/src/main/res/menu/menu_main.xml
+++ b/tools/eddystone-validator/EddystoneValidator/app/src/main/res/menu/menu_main.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/actionSettings"
+        android:orderInCategory="100"
+        android:showAsAction="never"
+        android:title="@string/action_settings" />
+
+</menu>

--- a/tools/eddystone-validator/EddystoneValidator/app/src/main/res/values/attrs.xml
+++ b/tools/eddystone-validator/EddystoneValidator/app/src/main/res/values/attrs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <declare-styleable name="NumberPickerPreference">
+        <attr name="max" format="integer" />
+        <attr name="min" format="integer" />
+    </declare-styleable>
+
+</resources>

--- a/tools/eddystone-validator/EddystoneValidator/app/src/main/res/values/strings.xml
+++ b/tools/eddystone-validator/EddystoneValidator/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
 
     <string name="app_name">Eddystone Validator</string>
+    <string name="action_settings">Settings</string>
 
 </resources>

--- a/tools/eddystone-validator/EddystoneValidator/app/src/main/res/xml/preferences.xml
+++ b/tools/eddystone-validator/EddystoneValidator/app/src/main/res/xml/preferences.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.google.sample.eddystonevalidator.NumberPickerPreference
+        android:key="onLostTimeoutSecs"
+        android:title="On lost timeout"
+        android:summary=""
+        android:defaultValue="5"
+        app:min="0"
+        app:max="10" />
+
+    <CheckBoxPreference
+        android:key="showDebugInfo"
+        android:title="Show debug info"
+        android:summary="Show some deubg info like the number of sighted beacons."
+        android:defaultValue="false" />
+
+</PreferenceScreen>


### PR DESCRIPTION
Allows the lost timeout to be adjusted on the fly and adds
an option to show some debug info. Just shows the number of
currently sighted beacons right now.
