### PR TITLE
Remove docs test

### DIFF
--- a/libraries/javascript/eddystone-advertising/gulpfile.js
+++ b/libraries/javascript/eddystone-advertising/gulpfile.js
@@ -29,7 +29,9 @@ gulp.task('docs', () => {
 });
 
 gulp.task('test', [
-  'test:docs',
+// TODO(g-ortuno): Uncomment once jsdoc2md is fixed:
+// https://github.com/jsdoc2md/jsdoc-to-markdown/issues/29
+//  'test:docs',
   'test:dependencies',
   'test:browserify',
   'test:style',


### PR DESCRIPTION
Jsdoc2md is broken so I'm disabling the docs test until it gets fixed.