### PR TITLE
documentation suggestions

### DIFF
--- a/libraries/javascript/eddystone-advertising/README.md
+++ b/libraries/javascript/eddystone-advertising/README.md
@@ -57,6 +57,12 @@ eddystone.advertisements.forEach(advertisement => {
 <dt><a href="#module_platform">platform</a></dt>
 <dd></dd>
 </dl>
+## Members
+<dl>
+<dt><a href="#eddystone">eddystone</a></dt>
+<dd><p>The global eddystone instance.</p>
+</dd>
+</dl>
 <a name="module_eddystone-advertisement"></a>
 ## eddystone-advertisement
 **Example**  
@@ -289,3 +295,8 @@ Detects what API is available in the platform.
 
 - <code>Error</code> If the platform is unsupported
 
+<a name="eddystone"></a>
+## eddystone
+The global eddystone instance.
+
+**Kind**: global variable  

--- a/libraries/javascript/eddystone-advertising/README.md
+++ b/libraries/javascript/eddystone-advertising/README.md
@@ -45,6 +45,7 @@ eddystone.advertisements.forEach(advertisement => {
 ```
 ## API
 ## Modules
+
 <dl>
 <dt><a href="#module_eddystone-advertisement">eddystone-advertisement</a></dt>
 <dd></dd>
@@ -57,12 +58,15 @@ eddystone.advertisements.forEach(advertisement => {
 <dt><a href="#module_platform">platform</a></dt>
 <dd></dd>
 </dl>
+
 ## Members
+
 <dl>
 <dt><a href="#eddystone">eddystone</a> : <code><a href="#exp_module_eddystone-advertising--Eddystone">Eddystone</a></code></dt>
 <dd><p>The global eddystone instance.</p>
 </dd>
 </dl>
+
 <a name="module_eddystone-advertisement"></a>
 ## eddystone-advertisement
 **Example**  
@@ -71,28 +75,36 @@ const eddystoneAd = require('eddystone-advertisement')
 ```
 
 * [eddystone-advertisement](#module_eddystone-advertisement)
-  * [.EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)
-    * [new EddystoneAdvertisement(id, options, platform)](#new_module_eddystone-advertisement.EddystoneAdvertisement_new)
-    * [.unregisterAdvertisement()](#module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
-  * [.EddystoneFrameType](#module_eddystone-advertisement.EddystoneFrameType) : <code>enum</code>
+    * [.EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)
+        * [new EddystoneAdvertisement(id, options, platform)](#new_module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement)
+        * [.id](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+id) : <code>number</code>
+        * [.type](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+type) : <code>string</code>
+        * [.url](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+url) : <code>string</code> &#124; <code>undefined</code>
+        * [.advertisedTxPower](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+advertisedTxPower) : <code>number</code> &#124; <code>undefined</code>
+        * [.unregisterAdvertisement()](#module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.EddystoneFrameType](#module_eddystone-advertisement.EddystoneFrameType) : <code>enum</code>
 
 <a name="module_eddystone-advertisement.EddystoneAdvertisement"></a>
 ### eddystoneAd.EddystoneAdvertisement
 Represents the Advertisement being broadcasted.
 
 **Kind**: static class of <code>[eddystone-advertisement](#module_eddystone-advertisement)</code>  
-
-* [.EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)
-  * [new EddystoneAdvertisement(id, options, platform)](#new_module_eddystone-advertisement.EddystoneAdvertisement_new)
-  * [.unregisterAdvertisement()](#module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
-
-<a name="new_module_eddystone-advertisement.EddystoneAdvertisement_new"></a>
-#### new EddystoneAdvertisement(id, options, platform)
 **Throws**:
 
 - <code>TypeError</code> If no platform was passed.
 - <code>Error</code> If type is an unsupported Frame Type.
 
+
+* [.EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)
+    * [new EddystoneAdvertisement(id, options, platform)](#new_module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement)
+    * [.id](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+id) : <code>number</code>
+    * [.type](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+type) : <code>string</code>
+    * [.url](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+url) : <code>string</code> &#124; <code>undefined</code>
+    * [.advertisedTxPower](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+advertisedTxPower) : <code>number</code> &#124; <code>undefined</code>
+    * [.unregisterAdvertisement()](#module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
+
+<a name="new_module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement"></a>
+#### new EddystoneAdvertisement(id, options, platform)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -100,6 +112,26 @@ Represents the Advertisement being broadcasted.
 | options | <code>EddystoneAdvertisementOptions</code> | The options used when        creating the advertisement. |
 | platform | <code>Object</code> | The underlying platform; used to unregister the        advertisement. |
 
+<a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+id"></a>
+#### eddystoneAdvertisement.id : <code>number</code>
+The ID of this advertisment.
+
+**Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
+<a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+type"></a>
+#### eddystoneAdvertisement.type : <code>string</code>
+The Eddystone Type
+
+**Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
+<a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+url"></a>
+#### eddystoneAdvertisement.url : <code>string</code> &#124; <code>undefined</code>
+URL being advertised. Only present if `type === 'url'`.
+
+**Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
+<a name="module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+advertisedTxPower"></a>
+#### eddystoneAdvertisement.advertisedTxPower : <code>number</code> &#124; <code>undefined</code>
+Tx Power included in the advertisement. Only present if `type === 'url'`.
+
+**Kind**: instance property of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
 <a name="module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement"></a>
 #### eddystoneAdvertisement.unregisterAdvertisement() ⇒ <code>Promise.&lt;void&gt;</code>
 Unregisters the current advertisement.
@@ -134,11 +166,12 @@ Possible Eddystone frame types.
 ## eddystone-advertising
 
 * [eddystone-advertising](#module_eddystone-advertising)
-  * [Eddystone](#exp_module_eddystone-advertising--Eddystone) ⏏
-    * _instance_
-      * [.registerAdvertisement()](#module_eddystone-advertising--Eddystone+registerAdvertisement) ⇒ <code>Promise.&lt;EddystoneAdvertisement&gt;</code>
-    * _inner_
-      * [~EddystoneAdvertisementOptions](#module_eddystone-advertising--Eddystone..EddystoneAdvertisementOptions) : <code>Object</code>
+    * [Eddystone](#exp_module_eddystone-advertising--Eddystone) ⏏
+        * _instance_
+            * [.advertisements](#module_eddystone-advertising--Eddystone.Eddystone+advertisements) : <code>Array.&lt;EddystoneAdvertisement&gt;</code>
+            * [.registerAdvertisement()](#module_eddystone-advertising--Eddystone+registerAdvertisement) ⇒ <code>Promise.&lt;EddystoneAdvertisement&gt;</code>
+        * _inner_
+            * [~EddystoneAdvertisementOptions](#module_eddystone-advertising--Eddystone..EddystoneAdvertisementOptions) : <code>Object</code>
 
 <a name="exp_module_eddystone-advertising--Eddystone"></a>
 ### Eddystone ⏏
@@ -146,6 +179,13 @@ Exposes platform independent functions to register/unregister Eddystone
      Advertisements.
 
 **Kind**: Exported class  
+<a name="module_eddystone-advertising--Eddystone.Eddystone+advertisements"></a>
+#### eddystone.advertisements : <code>Array.&lt;EddystoneAdvertisement&gt;</code>
+Contains all previously registered advertisements.
+**Note:** In a Chrome App, if the event page gets killed users
+         won't be able to unregister the advertisement.
+
+**Kind**: instance property of <code>[Eddystone](#exp_module_eddystone-advertising--Eddystone)</code>  
 <a name="module_eddystone-advertising--Eddystone+registerAdvertisement"></a>
 #### eddystone.registerAdvertisement() ⇒ <code>Promise.&lt;EddystoneAdvertisement&gt;</code>
 Function to register an Eddystone BLE advertisement.
@@ -173,15 +213,13 @@ Object that contains the characteristics of the package to advertise.
 ## eddystone-chrome-os
 
 * [eddystone-chrome-os](#module_eddystone-chrome-os)
-  * [EddystoneChromeOS](#exp_module_eddystone-chrome-os--EddystoneChromeOS) ⏏
-    * [.registerAdvertisement(options)](#module_eddystone-chrome-os--EddystoneChromeOS.registerAdvertisement) ⇒ <code>Promise.&lt;EddystoneAdvertisement&gt;</code>
-    * [.unregisterAdvertisement(advertisement)](#module_eddystone-chrome-os--EddystoneChromeOS.unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [._constructAdvertisement()](#module_eddystone-chrome-os--EddystoneChromeOS._constructAdvertisement) ⇒ <code>ChromeOSAdvertisement</code>
+    * [EddystoneChromeOS](#exp_module_eddystone-chrome-os--EddystoneChromeOS) ⏏
+        * [.registerAdvertisement(options)](#module_eddystone-chrome-os--EddystoneChromeOS.registerAdvertisement) ⇒ <code>Promise.&lt;EddystoneAdvertisement&gt;</code>
+        * [.unregisterAdvertisement(advertisement)](#module_eddystone-chrome-os--EddystoneChromeOS.unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
+        * [._constructAdvertisement()](#module_eddystone-chrome-os--EddystoneChromeOS._constructAdvertisement) ⇒ <code>ChromeOSAdvertisement</code>
 
 <a name="exp_module_eddystone-chrome-os--EddystoneChromeOS"></a>
 ### EddystoneChromeOS ⏏
-This class wraps the underlying ChromeOS BLE Advertising API.
-
 **Kind**: Exported class  
 **Todo**
 
@@ -236,15 +274,24 @@ Construct the ChromeOS specific advertisement to register.
 ## eddystone-url
 
 * [eddystone-url](#module_eddystone-url)
-  * [EddystoneURL](#exp_module_eddystone-url--EddystoneURL) ⏏
-    * [.constructServiceData(url, advertisedTxPower)](#module_eddystone-url--EddystoneURL.constructServiceData) ⇒ <code>Array.&lt;number&gt;</code>
-    * [.encodeURL(url)](#module_eddystone-url--EddystoneURL.encodeURL) ⇒ <code>Array.&lt;number&gt;</code>
+    * [EddystoneURL](#exp_module_eddystone-url--EddystoneURL) ⏏
+        * [.constructServiceData(url, advertisedTxPower)](#module_eddystone-url--EddystoneURL.constructServiceData) ⇒ <code>Array.&lt;number&gt;</code>
+        * [.encodeURL(url)](#module_eddystone-url--EddystoneURL.encodeURL) ⇒ <code>Array.&lt;number&gt;</code>
 
 <a name="exp_module_eddystone-url--EddystoneURL"></a>
 ### EddystoneURL ⏏
-This class provides helper functions that relate to Eddystone-URL.
-
 **Kind**: Exported class  
+**Throws**:
+
+- <code>Error</code> If the Tx Power value is not in the allowed range. See
+     [Tx Power Level](https://github.com/google/eddystone/tree/master/eddystone-url#tx-power-level).
+- <code>Error</code> If the URL Scheme prefix is unsupported. For a list of
+     supported Scheme prefixes see
+     [URL Scheme Prefix](https://github.com/google/eddystone/tree/master/eddystone-url#url-scheme-prefix)
+- <code>Error</code> If the URL contains an invalid character. For a list of
+     invalid characters see the Note in
+     [HTTP URL Encoding](https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url-http-url-encoding)
+
 **See**: [Eddystone-URL](https://github.com/google/eddystone/tree/master/eddystone-url)  
 <a name="module_eddystone-url--EddystoneURL.constructServiceData"></a>
 #### EddystoneURL.constructServiceData(url, advertisedTxPower) ⇒ <code>Array.&lt;number&gt;</code>

--- a/libraries/javascript/eddystone-advertising/README.md
+++ b/libraries/javascript/eddystone-advertising/README.md
@@ -59,7 +59,7 @@ eddystone.advertisements.forEach(advertisement => {
 </dl>
 ## Members
 <dl>
-<dt><a href="#eddystone">eddystone</a></dt>
+<dt><a href="#eddystone">eddystone</a> : <code><a href="#exp_module_eddystone-advertising--Eddystone">Eddystone</a></code></dt>
 <dd><p>The global eddystone instance.</p>
 </dd>
 </dl>
@@ -296,7 +296,7 @@ Detects what API is available in the platform.
 - <code>Error</code> If the platform is unsupported
 
 <a name="eddystone"></a>
-## eddystone
+## eddystone : <code>[Eddystone](#exp_module_eddystone-advertising--Eddystone)</code>
 The global eddystone instance.
 
 **Kind**: global variable  

--- a/libraries/javascript/eddystone-advertising/README.md
+++ b/libraries/javascript/eddystone-advertising/README.md
@@ -7,8 +7,8 @@ protocol and wraps existing Advertising APIs so that developers don't have to
 worry about these low level details. The library exposes simple functions that
 developers can use to advertise a Valid Eddystone packet from their device.
 
-** NOTE ** Currently only ChromeOS is supported.
-** NOTE ** Currently only Eddystone-URL is supported.
+**NOTE** Currently only ChromeOS is supported.  
+**NOTE** Currently only Eddystone-URL is supported.
 
 ## Usage
 The Eddystone Advertising Library creates `window.eddystone` of type
@@ -44,177 +44,70 @@ eddystone.advertisements.forEach(advertisement => {
 });
 ```
 ## API
-## Classes
+## Modules
 <dl>
-<dt><a href="#EddystoneAdvertisement">EddystoneAdvertisement</a></dt>
-<dd><p>Represents the Advertisement being broadcasted.</p>
-</dd>
-<dt><a href="#Eddystone">Eddystone</a></dt>
-<dd><p>Exposes platform independent functions to register/unregister Eddystone
-     Advertisements.</p>
-</dd>
-<dt><a href="#EddystoneURL">EddystoneURL</a></dt>
-<dd><p>This class provides helper functions that relate to Eddystone-URL.</p>
-</dd>
+<dt><a href="#module_eddystone-advertisement">eddystone-advertisement</a></dt>
+<dd></dd>
+<dt><a href="#module_eddystone-advertising">eddystone-advertising</a></dt>
+<dd></dd>
+<dt><a href="#module_eddystone-chrome-os">eddystone-chrome-os</a></dt>
+<dd></dd>
+<dt><a href="#module_eddystone-url">eddystone-url</a></dt>
+<dd></dd>
+<dt><a href="#module_platform">platform</a></dt>
+<dd></dd>
 </dl>
-## Constants
-<dl>
-<dt><a href="#EddystoneFrameType">EddystoneFrameType</a> : <code>enum</code></dt>
-<dd><p>Possible Eddystone frame types.</p>
-</dd>
-</dl>
-## Typedefs
-<dl>
-<dt><a href="#EddystoneAdvertisementOptions">EddystoneAdvertisementOptions</a> : <code>Object</code></dt>
-<dd><p>Object that contains the characteristics of the package to advertise.</p>
-</dd>
-</dl>
-<a name="EddystoneAdvertisement"></a>
-## EddystoneAdvertisement
+<a name="module_eddystone-advertisement"></a>
+## eddystone-advertisement
+**Example**  
+```js
+const eddystoneAd = require('eddystone-advertisement')
+```
+
+* [eddystone-advertisement](#module_eddystone-advertisement)
+  * [.EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)
+    * [new EddystoneAdvertisement(id, options, platform)](#new_module_eddystone-advertisement.EddystoneAdvertisement_new)
+    * [.unregisterAdvertisement()](#module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
+  * [.EddystoneFrameType](#module_eddystone-advertisement.EddystoneFrameType) : <code>enum</code>
+
+<a name="module_eddystone-advertisement.EddystoneAdvertisement"></a>
+### eddystoneAd.EddystoneAdvertisement
 Represents the Advertisement being broadcasted.
 
-**Kind**: global class  
+**Kind**: static class of <code>[eddystone-advertisement](#module_eddystone-advertisement)</code>  
 
-* [EddystoneAdvertisement](#EddystoneAdvertisement)
-  * [new EddystoneAdvertisement(id, options, platform)](#new_EddystoneAdvertisement_new)
-  * [.id](#EddystoneAdvertisement+id) : <code>number</code>
-  * [.type](#EddystoneAdvertisement+type) : <code>string</code>
-  * [.url](#EddystoneAdvertisement+url) : <code>string</code> &#124; <code>undefined</code>
-  * [.advertisedTxPower](#EddystoneAdvertisement+advertisedTxPower) : <code>number</code> &#124; <code>undefined</code>
-  * [.unregisterAdvertisement()](#EddystoneAdvertisement+unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
+* [.EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)
+  * [new EddystoneAdvertisement(id, options, platform)](#new_module_eddystone-advertisement.EddystoneAdvertisement_new)
+  * [.unregisterAdvertisement()](#module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
 
-<a name="new_EddystoneAdvertisement_new"></a>
-### new EddystoneAdvertisement(id, options, platform)
+<a name="new_module_eddystone-advertisement.EddystoneAdvertisement_new"></a>
+#### new EddystoneAdvertisement(id, options, platform)
+**Throws**:
+
+- <code>TypeError</code> If no platform was passed.
+- <code>Error</code> If type is an unsupported Frame Type.
+
 
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>number</code> | Unique between browser restarts meaning the id will        no longer be valid upon browser restart. |
-| options | <code>[EddystoneAdvertisementOptions](#EddystoneAdvertisementOptions)</code> | The options used when        creating the advertisement. |
+| options | <code>EddystoneAdvertisementOptions</code> | The options used when        creating the advertisement. |
 | platform | <code>Object</code> | The underlying platform; used to unregister the        advertisement. |
 
-<a name="EddystoneAdvertisement+id"></a>
-### eddystoneAdvertisement.id : <code>number</code>
-The ID of this advertisment.
-
-**Kind**: instance property of <code>[EddystoneAdvertisement](#EddystoneAdvertisement)</code>  
-<a name="EddystoneAdvertisement+type"></a>
-### eddystoneAdvertisement.type : <code>string</code>
-The Eddystone Type
-
-**Kind**: instance property of <code>[EddystoneAdvertisement](#EddystoneAdvertisement)</code>  
-<a name="EddystoneAdvertisement+url"></a>
-### eddystoneAdvertisement.url : <code>string</code> &#124; <code>undefined</code>
-URL being advertised.
-         Only present if `type === 'url'`.
-
-**Kind**: instance property of <code>[EddystoneAdvertisement](#EddystoneAdvertisement)</code>  
-<a name="EddystoneAdvertisement+advertisedTxPower"></a>
-### eddystoneAdvertisement.advertisedTxPower : <code>number</code> &#124; <code>undefined</code>
-Tx Power included in
-         the advertisement. Only present if `type === 'url'`.
-
-**Kind**: instance property of <code>[EddystoneAdvertisement](#EddystoneAdvertisement)</code>  
-<a name="EddystoneAdvertisement+unregisterAdvertisement"></a>
-### eddystoneAdvertisement.unregisterAdvertisement() ⇒ <code>Promise.&lt;void&gt;</code>
+<a name="module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement"></a>
+#### eddystoneAdvertisement.unregisterAdvertisement() ⇒ <code>Promise.&lt;void&gt;</code>
 Unregisters the current advertisement.
 
-**Kind**: instance method of <code>[EddystoneAdvertisement](#EddystoneAdvertisement)</code>  
+**Kind**: instance method of <code>[EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)</code>  
 **Fulfill**: <code>void</code> - If the advertisement was unregistered successfully.  
 **Reject**: <code>Error</code> - If the advertisement failed to be registered. If
        the promise rejects the advertisment may still be broadcasting. The only
        way to recover may be to reboot your machine.  
-<a name="Eddystone"></a>
-## Eddystone
-Exposes platform independent functions to register/unregister Eddystone
-     Advertisements.
-
-**Kind**: global class  
-
-* [Eddystone](#Eddystone)
-  * [.advertisements](#Eddystone+advertisements) : <code>[Array.&lt;EddystoneAdvertisement&gt;](#EddystoneAdvertisement)</code>
-  * [.registerAdvertisement()](#Eddystone+registerAdvertisement) ⇒ <code>[Promise.&lt;EddystoneAdvertisement&gt;](#EddystoneAdvertisement)</code>
-
-<a name="Eddystone+advertisements"></a>
-### eddystone.advertisements : <code>[Array.&lt;EddystoneAdvertisement&gt;](#EddystoneAdvertisement)</code>
-Contains
-         all previously registered advertisements.<br>
-**Note:** In a Chrome App, if the event page gets killed users won't
-         be able to unregister the advertisement.
-
-**Kind**: instance property of <code>[Eddystone](#Eddystone)</code>  
-<a name="Eddystone+registerAdvertisement"></a>
-### eddystone.registerAdvertisement() ⇒ <code>[Promise.&lt;EddystoneAdvertisement&gt;](#EddystoneAdvertisement)</code>
-Function to register an Eddystone BLE advertisement.
-
-**Kind**: instance method of <code>[Eddystone](#Eddystone)</code>  
-**Params**: <code>[EddystoneAdvertisementOptions](#EddystoneAdvertisementOptions)</code> options The characteristics
-       of the advertised Eddystone.  
-**Fulfill**: <code>[EddystoneAdvertisement](#EddystoneAdvertisement)</code> - If the advertisement was registered
-       successfully.  
-**Reject**: <code>Error</code> - If the advertisement failed to be registered.  
-<a name="EddystoneURL"></a>
-## EddystoneURL
-This class provides helper functions that relate to Eddystone-URL.
-
-**Kind**: global class  
-**See**: [Eddystone-URL](https://github.com/google/eddystone/tree/master/eddystone-url)  
-
-* [EddystoneURL](#EddystoneURL)
-  * [.constructServiceData(url, advertisedTxPower)](#EddystoneURL.constructServiceData) ⇒ <code>Array.&lt;number&gt;</code>
-  * [.encodeURL(url)](#EddystoneURL.encodeURL) ⇒ <code>Array.&lt;number&gt;</code>
-
-<a name="EddystoneURL.constructServiceData"></a>
-### EddystoneURL.constructServiceData(url, advertisedTxPower) ⇒ <code>Array.&lt;number&gt;</code>
-Constructs a valid Eddystone-URL service data from a URL and a Tx Power
-       value.
-
-**Kind**: static method of <code>[EddystoneURL](#EddystoneURL)</code>  
-**Returns**: <code>Array.&lt;number&gt;</code> - The service data.  
-**Throws**:
-
-- <code>Error</code> If the Tx Power value is not in the allowed range. See
-       [Tx Power Level](https://github.com/google/eddystone/tree/master/eddystone-url#tx-power-level).
-- <code>Error</code> If the URL Scheme prefix is unsupported. For a list of
-       supported Scheme prefixes see
-       [URL Scheme Prefix](https://github.com/google/eddystone/tree/master/eddystone-url#url-scheme-prefix)
-- <code>Error</code> If the URL contains an invalid character. For a list of
-       invalid characters see the Note in
-       [HTTP URL Encoding](https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url-http-url-encoding)
-
-**See**: [URL Frame Specification](https://github.com/google/eddystone/tree/master/eddystone-url#frame-specification)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| url | <code>string</code> | The URL to use in the service data. |
-| advertisedTxPower | <code>number</code> | The Tx Power to use in the service data. |
-
-<a name="EddystoneURL.encodeURL"></a>
-### EddystoneURL.encodeURL(url) ⇒ <code>Array.&lt;number&gt;</code>
-Encodes the given string using the encoding defined in the Eddystone-URL
-       Spec.
-
-**Kind**: static method of <code>[EddystoneURL](#EddystoneURL)</code>  
-**Returns**: <code>Array.&lt;number&gt;</code> - The encoded url.  
-**Throws**:
-
-- <code>Error</code> If the URL Scheme prefix is unsupported. For a list of
-       supported Scheme prefixes see:
-       https://github.com/google/eddystone/tree/master/eddystone-url#url-scheme-prefix
-- <code>Error</code> If the URL contains an invalid character. For a list of
-       invalid characters see the Note in:
-       https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url-http-url-encoding
-
-**See**: [Eddystone-URL](https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| url | <code>string</code> | The url to encode. |
-
-<a name="EddystoneFrameType"></a>
-## EddystoneFrameType : <code>enum</code>
+<a name="module_eddystone-advertisement.EddystoneFrameType"></a>
+### eddystoneAd.EddystoneFrameType : <code>enum</code>
 Possible Eddystone frame types.
 
-**Kind**: global constant  
+**Kind**: static constant of <code>[eddystone-advertisement](#module_eddystone-advertisement)</code>  
 **Read only**: true  
 **See**
 
@@ -231,16 +124,168 @@ Possible Eddystone frame types.
 | UID | <code>string</code> | <code>&quot;uid&quot;</code> | 
 | TLM | <code>string</code> | <code>&quot;tlm&quot;</code> | 
 
-<a name="EddystoneAdvertisementOptions"></a>
-## EddystoneAdvertisementOptions : <code>Object</code>
+<a name="module_eddystone-advertising"></a>
+## eddystone-advertising
+
+* [eddystone-advertising](#module_eddystone-advertising)
+  * [Eddystone](#exp_module_eddystone-advertising--Eddystone) ⏏
+    * _instance_
+      * [.registerAdvertisement()](#module_eddystone-advertising--Eddystone+registerAdvertisement) ⇒ <code>Promise.&lt;EddystoneAdvertisement&gt;</code>
+    * _inner_
+      * [~EddystoneAdvertisementOptions](#module_eddystone-advertising--Eddystone..EddystoneAdvertisementOptions) : <code>Object</code>
+
+<a name="exp_module_eddystone-advertising--Eddystone"></a>
+### Eddystone ⏏
+Exposes platform independent functions to register/unregister Eddystone
+     Advertisements.
+
+**Kind**: Exported class  
+<a name="module_eddystone-advertising--Eddystone+registerAdvertisement"></a>
+#### eddystone.registerAdvertisement() ⇒ <code>Promise.&lt;EddystoneAdvertisement&gt;</code>
+Function to register an Eddystone BLE advertisement.
+
+**Kind**: instance method of <code>[Eddystone](#exp_module_eddystone-advertising--Eddystone)</code>  
+**Params**: <code>EddystoneAdvertisementOptions</code> options The characteristics
+       of the advertised Eddystone.  
+**Fulfill**: <code>EddystoneAdvertisement</code> - If the advertisement was registered
+       successfully.  
+**Reject**: <code>Error</code> - If the advertisement failed to be registered.  
+<a name="module_eddystone-advertising--Eddystone..EddystoneAdvertisementOptions"></a>
+#### Eddystone~EddystoneAdvertisementOptions : <code>Object</code>
 Object that contains the characteristics of the package to advertise.
 
-**Kind**: global typedef  
+**Kind**: inner typedef of <code>[Eddystone](#exp_module_eddystone-advertising--Eddystone)</code>  
 **Properties**
 
 | Name | Type | Description |
 | --- | --- | --- |
-| type | <code>[EddystoneFrameType](#EddystoneFrameType)</code> | Type of Eddystone. For now only `'url'` is      supported. |
+| type | <code>EddystoneFrameType</code> | Type of Eddystone. For now only `'url'` is      supported. |
 | url | <code>string</code> &#124; <code>undefined</code> | The URL to advertise |
 | advertisedTxPower | <code>number</code> &#124; <code>undefined</code> | The Tx Power to advertise |
+
+<a name="module_eddystone-chrome-os"></a>
+## eddystone-chrome-os
+
+* [eddystone-chrome-os](#module_eddystone-chrome-os)
+  * [EddystoneChromeOS](#exp_module_eddystone-chrome-os--EddystoneChromeOS) ⏏
+    * [.registerAdvertisement(options)](#module_eddystone-chrome-os--EddystoneChromeOS.registerAdvertisement) ⇒ <code>Promise.&lt;EddystoneAdvertisement&gt;</code>
+    * [.unregisterAdvertisement(advertisement)](#module_eddystone-chrome-os--EddystoneChromeOS.unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [._constructAdvertisement()](#module_eddystone-chrome-os--EddystoneChromeOS._constructAdvertisement) ⇒ <code>ChromeOSAdvertisement</code>
+
+<a name="exp_module_eddystone-chrome-os--EddystoneChromeOS"></a>
+### EddystoneChromeOS ⏏
+This class wraps the underlying ChromeOS BLE Advertising API.
+
+**Kind**: Exported class  
+**Todo**
+
+- [ ] Add link to API.
+
+<a name="module_eddystone-chrome-os--EddystoneChromeOS.registerAdvertisement"></a>
+#### EddystoneChromeOS.registerAdvertisement(options) ⇒ <code>Promise.&lt;EddystoneAdvertisement&gt;</code>
+Function that registers an Eddystone BLE advertisement.
+
+**Kind**: static method of <code>[EddystoneChromeOS](#exp_module_eddystone-chrome-os--EddystoneChromeOS)</code>  
+**Fulfill**: <code>EddystoneAdvertisement</code> - If the advertisement was registered
+       successfully.  
+**Reject**: <code>Error</code> - If the advertisement failed to be regsitered.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>EddystoneAdvertisementOptions</code> | The characteristics of the        advertisement. |
+
+<a name="module_eddystone-chrome-os--EddystoneChromeOS.unregisterAdvertisement"></a>
+#### EddystoneChromeOS.unregisterAdvertisement(advertisement) ⇒ <code>Promise.&lt;void&gt;</code>
+Function to unregister an advertisement.
+
+**Kind**: static method of <code>[EddystoneChromeOS](#exp_module_eddystone-chrome-os--EddystoneChromeOS)</code>  
+**Fulfill**: <code>void</code> - If the advertisment was unregistered successfully.  
+**Reject**: <code>Error</code> - If the advertisment failed to be unregistered.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| advertisement | <code>EddystoneAdvertisement</code> | The advertisement to        unregister. |
+
+<a name="module_eddystone-chrome-os--EddystoneChromeOS._constructAdvertisement"></a>
+#### EddystoneChromeOS._constructAdvertisement() ⇒ <code>ChromeOSAdvertisement</code>
+Construct the ChromeOS specific advertisement to register.
+
+**Kind**: static method of <code>[EddystoneChromeOS](#exp_module_eddystone-chrome-os--EddystoneChromeOS)</code>  
+**Returns**: <code>ChromeOSAdvertisement</code> - advertisement  
+**Throws**:
+
+- <code>Error</code> If the frame type is not supported
+- <code>Error</code> If the Tx Power value is not in the allowed range. See:
+       https://github.com/google/eddystone/tree/master/eddystone-url#tx-power-level
+- <code>Error</code> If the URL Scheme prefix is unsupported. For a list of
+       supported Scheme prefixes see:
+       https://github.com/google/eddystone/tree/master/eddystone-url#url-scheme-prefix
+- <code>Error</code> If the URL contains an invalid character. For a list of
+       invalid characters see the Note in:
+       https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url-http-url-encoding
+
+**Params**: <code>EddystoneAdvertisementOptions</code> options The characteristics of the
+       advertisement.  
+<a name="module_eddystone-url"></a>
+## eddystone-url
+
+* [eddystone-url](#module_eddystone-url)
+  * [EddystoneURL](#exp_module_eddystone-url--EddystoneURL) ⏏
+    * [.constructServiceData(url, advertisedTxPower)](#module_eddystone-url--EddystoneURL.constructServiceData) ⇒ <code>Array.&lt;number&gt;</code>
+    * [.encodeURL(url)](#module_eddystone-url--EddystoneURL.encodeURL) ⇒ <code>Array.&lt;number&gt;</code>
+
+<a name="exp_module_eddystone-url--EddystoneURL"></a>
+### EddystoneURL ⏏
+This class provides helper functions that relate to Eddystone-URL.
+
+**Kind**: Exported class  
+**See**: [Eddystone-URL](https://github.com/google/eddystone/tree/master/eddystone-url)  
+<a name="module_eddystone-url--EddystoneURL.constructServiceData"></a>
+#### EddystoneURL.constructServiceData(url, advertisedTxPower) ⇒ <code>Array.&lt;number&gt;</code>
+Constructs a valid Eddystone-URL service data from a URL and a Tx Power
+       value.
+
+**Kind**: static method of <code>[EddystoneURL](#exp_module_eddystone-url--EddystoneURL)</code>  
+**Returns**: <code>Array.&lt;number&gt;</code> - The service data.  
+**See**: [URL Frame Specification](https://github.com/google/eddystone/tree/master/eddystone-url#frame-specification)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| url | <code>string</code> | The URL to use in the service data. |
+| advertisedTxPower | <code>number</code> | The Tx Power to use in the service data. |
+
+<a name="module_eddystone-url--EddystoneURL.encodeURL"></a>
+#### EddystoneURL.encodeURL(url) ⇒ <code>Array.&lt;number&gt;</code>
+Encodes the given string using the encoding defined in the Eddystone-URL
+       Spec.
+
+**Kind**: static method of <code>[EddystoneURL](#exp_module_eddystone-url--EddystoneURL)</code>  
+**Returns**: <code>Array.&lt;number&gt;</code> - The encoded url.  
+**Throws**:
+
+- <code>Error</code> If the URL Scheme prefix is unsupported. For a list of
+       supported Scheme prefixes see:
+       https://github.com/google/eddystone/tree/master/eddystone-url#url-scheme-prefix
+- <code>Error</code> If the URL contains an invalid character. For a list of
+       invalid characters see the Note in:
+       https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url-http-url-encoding
+
+**See**: [Eddystone-URL](https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| url | <code>string</code> | The url to encode. |
+
+<a name="module_platform"></a>
+## platform
+<a name="exp_module_platform--platform"></a>
+### platform() ⇒ <code>Object</code> ⏏
+Detects what API is available in the platform.
+
+**Kind**: Exported function  
+**Returns**: <code>Object</code> - An object that wraps the underlying BLE
+     Advertising API  
+**Throws**:
+
+- <code>Error</code> If the platform is unsupported
 

--- a/libraries/javascript/eddystone-advertising/README.md
+++ b/libraries/javascript/eddystone-advertising/README.md
@@ -76,7 +76,7 @@ const advertisement = require('eddystone-advertisement')
 
 * [eddystone-advertisement](#module_eddystone-advertisement)
     * [.EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)
-        * [new EddystoneAdvertisement(id, options, platform)](#new_module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement)
+        * [new EddystoneAdvertisement(id, options, platform)](#new_module_eddystone-advertisement.EddystoneAdvertisement_new)
         * [.id](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+id) : <code>number</code>
         * [.type](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+type) : <code>string</code>
         * [.url](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+url) : <code>string</code> &#124; <code>undefined</code>
@@ -89,22 +89,22 @@ const advertisement = require('eddystone-advertisement')
 Represents the Advertisement being broadcasted.
 
 **Kind**: static class of <code>[eddystone-advertisement](#module_eddystone-advertisement)</code>  
-**Throws**:
-
-- <code>TypeError</code> If no platform was passed.
-- <code>Error</code> If type is an unsupported Frame Type.
-
 
 * [.EddystoneAdvertisement](#module_eddystone-advertisement.EddystoneAdvertisement)
-    * [new EddystoneAdvertisement(id, options, platform)](#new_module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement)
+    * [new EddystoneAdvertisement(id, options, platform)](#new_module_eddystone-advertisement.EddystoneAdvertisement_new)
     * [.id](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+id) : <code>number</code>
     * [.type](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+type) : <code>string</code>
     * [.url](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+url) : <code>string</code> &#124; <code>undefined</code>
     * [.advertisedTxPower](#module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement+advertisedTxPower) : <code>number</code> &#124; <code>undefined</code>
     * [.unregisterAdvertisement()](#module_eddystone-advertisement.EddystoneAdvertisement+unregisterAdvertisement) ⇒ <code>Promise.&lt;void&gt;</code>
 
-<a name="new_module_eddystone-advertisement.EddystoneAdvertisement.EddystoneAdvertisement"></a>
+<a name="new_module_eddystone-advertisement.EddystoneAdvertisement_new"></a>
 #### new EddystoneAdvertisement(id, options, platform)
+**Throws**:
+
+- <code>TypeError</code> If no platform was passed.
+- <code>Error</code> If type is an unsupported Frame Type.
+
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -220,6 +220,8 @@ Object that contains the characteristics of the package to advertise.
 
 <a name="exp_module_eddystone-chrome-os--EddystoneChromeOS"></a>
 ### EddystoneChromeOS ⏏
+This class wraps the underlying ChromeOS BLE Advertising API.
+
 **Kind**: Exported class  
 **Todo**
 
@@ -280,18 +282,9 @@ Construct the ChromeOS specific advertisement to register.
 
 <a name="exp_module_eddystone-url--EddystoneURL"></a>
 ### EddystoneURL ⏏
+This class provides helper functions that relate to Eddystone-URL.
+
 **Kind**: Exported class  
-**Throws**:
-
-- <code>Error</code> If the Tx Power value is not in the allowed range. See
-     [Tx Power Level](https://github.com/google/eddystone/tree/master/eddystone-url#tx-power-level).
-- <code>Error</code> If the URL Scheme prefix is unsupported. For a list of
-     supported Scheme prefixes see
-     [URL Scheme Prefix](https://github.com/google/eddystone/tree/master/eddystone-url#url-scheme-prefix)
-- <code>Error</code> If the URL contains an invalid character. For a list of
-     invalid characters see the Note in
-     [HTTP URL Encoding](https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url-http-url-encoding)
-
 **See**: [Eddystone-URL](https://github.com/google/eddystone/tree/master/eddystone-url)  
 <a name="module_eddystone-url--EddystoneURL.constructServiceData"></a>
 #### EddystoneURL.constructServiceData(url, advertisedTxPower) ⇒ <code>Array.&lt;number&gt;</code>

--- a/libraries/javascript/eddystone-advertising/README.md
+++ b/libraries/javascript/eddystone-advertising/README.md
@@ -71,7 +71,7 @@ eddystone.advertisements.forEach(advertisement => {
 ## eddystone-advertisement
 **Example**  
 ```js
-const eddystoneAd = require('eddystone-advertisement')
+const advertisement = require('eddystone-advertisement')
 ```
 
 * [eddystone-advertisement](#module_eddystone-advertisement)
@@ -85,7 +85,7 @@ const eddystoneAd = require('eddystone-advertisement')
     * [.EddystoneFrameType](#module_eddystone-advertisement.EddystoneFrameType) : <code>enum</code>
 
 <a name="module_eddystone-advertisement.EddystoneAdvertisement"></a>
-### eddystoneAd.EddystoneAdvertisement
+### advertisement.EddystoneAdvertisement
 Represents the Advertisement being broadcasted.
 
 **Kind**: static class of <code>[eddystone-advertisement](#module_eddystone-advertisement)</code>  
@@ -142,7 +142,7 @@ Unregisters the current advertisement.
        the promise rejects the advertisment may still be broadcasting. The only
        way to recover may be to reboot your machine.  
 <a name="module_eddystone-advertisement.EddystoneFrameType"></a>
-### eddystoneAd.EddystoneFrameType : <code>enum</code>
+### advertisement.EddystoneFrameType : <code>enum</code>
 Possible Eddystone frame types.
 
 **Kind**: static constant of <code>[eddystone-advertisement](#module_eddystone-advertisement)</code>  

--- a/libraries/javascript/eddystone-advertising/eddystone-advertising.js
+++ b/libraries/javascript/eddystone-advertising/eddystone-advertising.js
@@ -4,9 +4,9 @@
 
   /**
    * @module eddystone-advertisement
-   * @typicalname eddystoneAd
+   * @typicalname advertisement
    * @example
-   * const eddystoneAd = require('eddystone-advertisement')
+   * const advertisement = require('eddystone-advertisement')
    */
 
   /**
@@ -36,14 +36,12 @@
 
   /**
      Represents the Advertisement being broadcasted.
-     @class
      @throws {TypeError} If no platform was passed.
      @throws {Error} If type is an unsupported Frame Type.
      @alias module:eddystone-advertisement.EddystoneAdvertisement
    */
   class EddystoneAdvertisement {
     /**
-       @constructs EddystoneAdvertisement
        @param {number} id Unique between browser restarts meaning the id will
        no longer be valid upon browser restart.
        @param {EddystoneAdvertisementOptions} options The options used when
@@ -110,6 +108,7 @@
 
   /**
    * @module eddystone-advertising
+   * @typicalname advertising
    */
 
   let platform = require('./platform.js');
@@ -209,6 +208,7 @@
 
   /**
    * @module eddystone-chrome-os
+   * @typicalname chromeOS
    */
 
   let EddystoneURL = require('./eddystone-url.js');
@@ -313,6 +313,7 @@
 
   /**
    * @module eddystone-url
+   * @typicalname url
    */
 
   const EDDYSTONE_UUID = require('./eddystone-advertisement.js').EDDYSTONE_UUID;

--- a/libraries/javascript/eddystone-advertising/eddystone-advertising.js
+++ b/libraries/javascript/eddystone-advertising/eddystone-advertising.js
@@ -3,12 +3,20 @@
   'use strict';
 
   /**
+   * @module eddystone-advertisement
+   * @typicalname eddystoneAd
+   * @example
+   * const eddystoneAd = require('eddystone-advertisement')
+   */
+
+  /**
      Possible Eddystone frame types.
      @see {@link https://github.com/google/eddystone/blob/master/protocol-specification.md|Protocol Specification}
      @see {@link https://github.com/google/eddystone/tree/master/eddystone-url|Eddystone-URL}
      @see {@link https://github.com/google/eddystone/tree/master/eddystone-uid|Eddystone-UID}
      @see {@link https://github.com/google/eddystone/tree/master/eddystone-tlm|Eddystone-TLM}
      @readonly
+     @alias module:eddystone-advertisement.EddystoneFrameType
      @enum {string}
    */
   const EddystoneFrameType = {
@@ -22,12 +30,16 @@
      @private
      @constant {string}
      @default
+     @alias module:eddystone-advertisement.EDDYSTONE_UUID
    */
   const EDDYSTONE_UUID = 'FEAA';
 
   /**
      Represents the Advertisement being broadcasted.
      @class
+     @throws {TypeError} If no platform was passed.
+     @throws {Error} If type is an unsupported Frame Type.
+     @alias module:eddystone-advertisement.EddystoneAdvertisement
    */
   class EddystoneAdvertisement {
     /**
@@ -38,8 +50,6 @@
        creating the advertisement.
        @param {Object} platform The underlying platform; used to unregister the
        advertisement.
-       @throws {TypeError} If no platform was passed.
-       @throws {Error} If type is an unsupported Frame Type.
      */
     constructor(id, options, platform) {
       if (typeof platform === 'undefined') {
@@ -47,21 +57,23 @@
       }
       this._platform = platform;
       /**
-         @member EddystoneAdvertisement#id {number} The ID of this advertisment.
+         The ID of this advertisment.
+         @type {number}
        */
       this.id = undefined;
       /**
-         @member EddystoneAdvertisement#type {string} The Eddystone Type
+         The Eddystone Type
+         @type {string}
        */
       this.type = undefined;
       /**
-         @member EddystoneAdvertisement#url {string|undefined} URL being advertised.
-         Only present if `type === 'url'`.
+         URL being advertised. Only present if `type === 'url'`.
+         @type {string|undefined}
        */
       this.url = undefined;
       /**
-         @member EddystoneAdvertisement#advertisedTxPower {number|undefined} Tx Power included in
-         the advertisement. Only present if `type === 'url'`.
+         Tx Power included in the advertisement. Only present if `type === 'url'`.
+         @type {number|undefined}
        */
       this.advertisedTxPower = undefined;
       if (options.type == EddystoneFrameType.URL) {
@@ -86,14 +98,20 @@
       return this._platform.unregisterAdvertisement(this);
     }
   }
-  module.exports.EddystoneAdvertisement = EddystoneAdvertisement;
-  module.exports.EddystoneFrameType = EddystoneFrameType;
-  module.exports.EDDYSTONE_UUID = EDDYSTONE_UUID;
+
+  exports.EddystoneAdvertisement = EddystoneAdvertisement;
+  exports.EddystoneFrameType = EddystoneFrameType;
+  exports.EDDYSTONE_UUID = EDDYSTONE_UUID;
 })();
 
 },{}],2:[function(require,module,exports){
 (() => {
   'use strict';
+
+  /**
+   * @module eddystone-advertising
+   */
+
   let platform = require('./platform.js');
   let EddystoneFrameType = require('./eddystone-advertisement.js').EddystoneFrameType;
 
@@ -109,19 +127,17 @@
   /**
      Exposes platform independent functions to register/unregister Eddystone
      Advertisements.
-     @class
+     @alias module:eddystone-advertising
    */
   class Eddystone {
-    /**
-       @constructs Eddystone
-     */
     constructor() {
       this._platform = platform();
       /**
-         @member Eddystone#advertisements {EddystoneAdvertisement[]} Contains
-         all previously registered advertisements.<br>
-         ***Note:** In a Chrome App, if the event page gets killed users won't
-         be able to unregister the advertisement.
+         Contains all previously registered advertisements.
+
+         ***Note:** In a Chrome App, if the event page gets killed users
+         won't be able to unregister the advertisement.
+         @type {EddystoneAdvertisement[]}
        */
       this.advertisements = [];
     }
@@ -183,21 +199,26 @@
       }
     }
   }
+
   module.exports = Eddystone;
 })();
 
 },{"./eddystone-advertisement.js":1,"./platform.js":6}],3:[function(require,module,exports){
 (() => {
   'use strict';
+
+  /**
+   * @module eddystone-chrome-os
+   */
+
   let EddystoneURL = require('./eddystone-url.js');
   let EddystoneAdvertisement = require('./eddystone-advertisement.js').EddystoneAdvertisement;
   const EddystoneFrameType = require('./eddystone-advertisement.js').EddystoneFrameType;
   const EDDYSTONE_UUID = require('./eddystone-advertisement.js').EDDYSTONE_UUID;
   /**
      This class wraps the underlying ChromeOS BLE Advertising API.
-     TODO: Add link to API.
-     @private
-     @class EddystoneChromeOS
+     @todo Add link to API.
+     @alias module:eddystone-chrome-os
    */
   class EddystoneChromeOS {
     /**
@@ -290,6 +311,10 @@
 (() => {
   'use strict';
 
+  /**
+   * @module eddystone-url
+   */
+
   const EDDYSTONE_UUID = require('./eddystone-advertisement.js').EDDYSTONE_UUID;
 
   // If we are in a browser TextEncoder should be available already.
@@ -299,7 +324,7 @@
 
   /**
      Eddystone-URL Frame type.
-     @see {@link https://github.com/google/eddystone/tree/master/eddystone-url#frame-specification|Eddystone-URL} 
+     @see {@link https://github.com/google/eddystone/tree/master/eddystone-url#frame-specification|Eddystone-URL}
      @private
      @constant {number}
      @default
@@ -354,7 +379,15 @@
   /**
      This class provides helper functions that relate to Eddystone-URL.
      @see {@link https://github.com/google/eddystone/tree/master/eddystone-url|Eddystone-URL}
-     @class
+     @alias module:eddystone-url
+     @throws {Error} If the Tx Power value is not in the allowed range. See
+     {@link https://github.com/google/eddystone/tree/master/eddystone-url#tx-power-level|Tx Power Level}.
+     @throws {Error} If the URL Scheme prefix is unsupported. For a list of
+     supported Scheme prefixes see
+     {@link https://github.com/google/eddystone/tree/master/eddystone-url#url-scheme-prefix|URL Scheme Prefix}
+     @throws {Error} If the URL contains an invalid character. For a list of
+     invalid characters see the Note in
+     {@link https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url-http-url-encoding|HTTP URL Encoding}
    */
   class EddystoneURL {
     /**
@@ -364,14 +397,6 @@
        @param {string} url The URL to use in the service data.
        @param {number} advertisedTxPower The Tx Power to use in the service data.
        @returns {number[]} The service data.
-       @throws {Error} If the Tx Power value is not in the allowed range. See
-       {@link https://github.com/google/eddystone/tree/master/eddystone-url#tx-power-level|Tx Power Level}.
-       @throws {Error} If the URL Scheme prefix is unsupported. For a list of
-       supported Scheme prefixes see
-       {@link https://github.com/google/eddystone/tree/master/eddystone-url#url-scheme-prefix|URL Scheme Prefix}
-       @throws {Error} If the URL contains an invalid character. For a list of
-       invalid characters see the Note in
-       {@link https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url-http-url-encoding|HTTP URL Encoding}
      */
     static constructServiceData(url, advertisedTxPower) {
       // Check that it's a valid Tx Power
@@ -480,7 +505,12 @@
   // the dependency graph and load all needed modules.
   let Eddystone = require('./eddystone-advertising.js');
 
-  // browserify will replace global with window.
+  /**
+   * The global eddystone instance.
+   *
+   * @global
+   * @type module:eddystone-advertising
+   */
   global.eddystone = new Eddystone();
 })();
 
@@ -488,13 +518,18 @@
 },{"./eddystone-advertising.js":2}],6:[function(require,module,exports){
 (() => {
   'use strict';
+
+  /**
+   * @module platform
+   */
+
   let EddystoneChromeOS = require('./eddystone-chrome-os.js');
   /**
      Detects what API is available in the platform.
-     @private
      @returns {Object} An object that wraps the underlying BLE
      Advertising API
      @throws {Error} If the platform is unsupported
+     @alias module:platform
    */
   function platform() {
     if (typeof chrome !== 'undefined') {

--- a/libraries/javascript/eddystone-advertising/gulpfile.js
+++ b/libraries/javascript/eddystone-advertising/gulpfile.js
@@ -29,9 +29,7 @@ gulp.task('docs', () => {
 });
 
 gulp.task('test', [
-// TODO(g-ortuno): Uncomment once jsdoc2md is fixed:
-// https://github.com/jsdoc2md/jsdoc-to-markdown/issues/29
-//  'test:docs',
+  'test:docs',
   'test:dependencies',
   'test:browserify',
   'test:style',

--- a/libraries/javascript/eddystone-advertising/jsdoc2md/README.hbs
+++ b/libraries/javascript/eddystone-advertising/jsdoc2md/README.hbs
@@ -7,8 +7,8 @@ protocol and wraps existing Advertising APIs so that developers don't have to
 worry about these low level details. The library exposes simple functions that
 developers can use to advertise a Valid Eddystone packet from their device.
 
-** NOTE ** Currently only ChromeOS is supported.
-** NOTE ** Currently only Eddystone-URL is supported.
+**NOTE** Currently only ChromeOS is supported.  
+**NOTE** Currently only Eddystone-URL is supported.
 
 ## Usage
 The Eddystone Advertising Library creates `window.eddystone` of type

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
@@ -2,12 +2,20 @@
   'use strict';
 
   /**
+   * @module eddystone-advertisement
+   * @typicalname eddystoneAd
+   * @example
+   * const eddystoneAd = require('eddystone-advertisement')
+   */
+
+  /**
      Possible Eddystone frame types.
      @see {@link https://github.com/google/eddystone/blob/master/protocol-specification.md|Protocol Specification}
      @see {@link https://github.com/google/eddystone/tree/master/eddystone-url|Eddystone-URL}
      @see {@link https://github.com/google/eddystone/tree/master/eddystone-uid|Eddystone-UID}
      @see {@link https://github.com/google/eddystone/tree/master/eddystone-tlm|Eddystone-TLM}
      @readonly
+     @alias module:eddystone-advertisement.EddystoneFrameType
      @enum {string}
    */
   const EddystoneFrameType = {
@@ -21,6 +29,7 @@
      @private
      @constant {string}
      @default
+     @alias module:eddystone-advertisement.EDDYSTONE_UUID
    */
   const EDDYSTONE_UUID = 'FEAA';
 
@@ -29,6 +38,7 @@
      @class
      @throws {TypeError} If no platform was passed.
      @throws {Error} If type is an unsupported Frame Type.
+     @alias module:eddystone-advertisement.EddystoneAdvertisement
    */
   class EddystoneAdvertisement {
     /**
@@ -87,7 +97,8 @@
       return this._platform.unregisterAdvertisement(this);
     }
   }
-  module.exports.EddystoneAdvertisement = EddystoneAdvertisement;
-  module.exports.EddystoneFrameType = EddystoneFrameType;
-  module.exports.EDDYSTONE_UUID = EDDYSTONE_UUID;
+
+  exports.EddystoneAdvertisement = EddystoneAdvertisement;
+  exports.EddystoneFrameType = EddystoneFrameType;
+  exports.EDDYSTONE_UUID = EDDYSTONE_UUID;
 })();

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
@@ -35,14 +35,12 @@
 
   /**
      Represents the Advertisement being broadcasted.
-     @class
      @throws {TypeError} If no platform was passed.
      @throws {Error} If type is an unsupported Frame Type.
      @alias module:eddystone-advertisement.EddystoneAdvertisement
    */
   class EddystoneAdvertisement {
     /**
-       @constructs EddystoneAdvertisement
        @param {number} id Unique between browser restarts meaning the id will
        no longer be valid upon browser restart.
        @param {EddystoneAdvertisementOptions} options The options used when

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
@@ -27,6 +27,8 @@
   /**
      Represents the Advertisement being broadcasted.
      @class
+     @throws {TypeError} If no platform was passed.
+     @throws {Error} If type is an unsupported Frame Type.
    */
   class EddystoneAdvertisement {
     /**
@@ -37,8 +39,6 @@
        creating the advertisement.
        @param {Object} platform The underlying platform; used to unregister the
        advertisement.
-       @throws {TypeError} If no platform was passed.
-       @throws {Error} If type is an unsupported Frame Type.
      */
     constructor(id, options, platform) {
       if (typeof platform === 'undefined') {

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
@@ -3,9 +3,9 @@
 
   /**
    * @module eddystone-advertisement
-   * @typicalname eddystoneAd
+   * @typicalname advertisement
    * @example
-   * const eddystoneAd = require('eddystone-advertisement')
+   * const advertisement = require('eddystone-advertisement')
    */
 
   /**

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-advertisement.js
@@ -46,21 +46,23 @@
       }
       this._platform = platform;
       /**
-         @member EddystoneAdvertisement#id {number} The ID of this advertisment.
+         The ID of this advertisment.
+         @type {number}
        */
       this.id = undefined;
       /**
-         @member EddystoneAdvertisement#type {string} The Eddystone Type
+         The Eddystone Type
+         @type {string}
        */
       this.type = undefined;
       /**
-         @member EddystoneAdvertisement#url {string|undefined} URL being advertised.
-         Only present if `type === 'url'`.
+         URL being advertised. Only present if `type === 'url'`.
+         @type {string|undefined}
        */
       this.url = undefined;
       /**
-         @member EddystoneAdvertisement#advertisedTxPower {number|undefined} Tx Power included in
-         the advertisement. Only present if `type === 'url'`.
+         Tx Power included in the advertisement. Only present if `type === 'url'`.
+         @type {number|undefined}
        */
       this.advertisedTxPower = undefined;
       if (options.type == EddystoneFrameType.URL) {

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-advertising.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-advertising.js
@@ -1,5 +1,10 @@
 (() => {
   'use strict';
+
+  /**
+   * @module eddystone-advertising
+   */
+
   let platform = require('./platform.js');
   let EddystoneFrameType = require('./eddystone-advertisement.js').EddystoneFrameType;
 
@@ -15,19 +20,17 @@
   /**
      Exposes platform independent functions to register/unregister Eddystone
      Advertisements.
-     @class
+     @alias module:eddystone-advertising
    */
   class Eddystone {
-    /**
-       @constructs Eddystone
-     */
     constructor() {
       this._platform = platform();
       /**
-         @member Eddystone#advertisements {EddystoneAdvertisement[]} Contains
-         all previously registered advertisements.<br>
-         ***Note:** In a Chrome App, if the event page gets killed users won't
-         be able to unregister the advertisement.
+         Contains all previously registered advertisements.
+
+         ***Note:** In a Chrome App, if the event page gets killed users
+         won't be able to unregister the advertisement.
+         @type {EddystoneAdvertisement[]}
        */
       this.advertisements = [];
     }
@@ -89,5 +92,6 @@
       }
     }
   }
+
   module.exports = Eddystone;
 })();

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-advertising.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-advertising.js
@@ -3,6 +3,7 @@
 
   /**
    * @module eddystone-advertising
+   * @typicalname advertising
    */
 
   let platform = require('./platform.js');

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-chrome-os.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-chrome-os.js
@@ -1,14 +1,18 @@
 (() => {
   'use strict';
+
+  /**
+   * @module eddystone-chrome-os
+   */
+
   let EddystoneURL = require('./eddystone-url.js');
   let EddystoneAdvertisement = require('./eddystone-advertisement.js').EddystoneAdvertisement;
   const EddystoneFrameType = require('./eddystone-advertisement.js').EddystoneFrameType;
   const EDDYSTONE_UUID = require('./eddystone-advertisement.js').EDDYSTONE_UUID;
   /**
      This class wraps the underlying ChromeOS BLE Advertising API.
-     TODO: Add link to API.
-     @private
-     @class EddystoneChromeOS
+     @todo Add link to API.
+     @alias module:eddystone-chrome-os
    */
   class EddystoneChromeOS {
     /**

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-chrome-os.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-chrome-os.js
@@ -3,6 +3,7 @@
 
   /**
    * @module eddystone-chrome-os
+   * @typicalname chromeOS
    */
 
   let EddystoneURL = require('./eddystone-url.js');

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-url.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-url.js
@@ -3,6 +3,7 @@
 
   /**
    * @module eddystone-url
+   * @typicalname url
    */
 
   const EDDYSTONE_UUID = require('./eddystone-advertisement.js').EDDYSTONE_UUID;

--- a/libraries/javascript/eddystone-advertising/lib/eddystone-url.js
+++ b/libraries/javascript/eddystone-advertising/lib/eddystone-url.js
@@ -1,6 +1,10 @@
 (() => {
   'use strict';
 
+  /**
+   * @module eddystone-url
+   */
+
   const EDDYSTONE_UUID = require('./eddystone-advertisement.js').EDDYSTONE_UUID;
 
   // If we are in a browser TextEncoder should be available already.
@@ -10,7 +14,7 @@
 
   /**
      Eddystone-URL Frame type.
-     @see {@link https://github.com/google/eddystone/tree/master/eddystone-url#frame-specification|Eddystone-URL} 
+     @see {@link https://github.com/google/eddystone/tree/master/eddystone-url#frame-specification|Eddystone-URL}
      @private
      @constant {number}
      @default
@@ -65,7 +69,15 @@
   /**
      This class provides helper functions that relate to Eddystone-URL.
      @see {@link https://github.com/google/eddystone/tree/master/eddystone-url|Eddystone-URL}
-     @class
+     @alias module:eddystone-url
+     @throws {Error} If the Tx Power value is not in the allowed range. See
+     {@link https://github.com/google/eddystone/tree/master/eddystone-url#tx-power-level|Tx Power Level}.
+     @throws {Error} If the URL Scheme prefix is unsupported. For a list of
+     supported Scheme prefixes see
+     {@link https://github.com/google/eddystone/tree/master/eddystone-url#url-scheme-prefix|URL Scheme Prefix}
+     @throws {Error} If the URL contains an invalid character. For a list of
+     invalid characters see the Note in
+     {@link https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url-http-url-encoding|HTTP URL Encoding}
    */
   class EddystoneURL {
     /**
@@ -75,14 +87,6 @@
        @param {string} url The URL to use in the service data.
        @param {number} advertisedTxPower The Tx Power to use in the service data.
        @returns {number[]} The service data.
-       @throws {Error} If the Tx Power value is not in the allowed range. See
-       {@link https://github.com/google/eddystone/tree/master/eddystone-url#tx-power-level|Tx Power Level}.
-       @throws {Error} If the URL Scheme prefix is unsupported. For a list of
-       supported Scheme prefixes see
-       {@link https://github.com/google/eddystone/tree/master/eddystone-url#url-scheme-prefix|URL Scheme Prefix}
-       @throws {Error} If the URL contains an invalid character. For a list of
-       invalid characters see the Note in
-       {@link https://github.com/google/eddystone/tree/master/eddystone-url#eddystone-url-http-url-encoding|HTTP URL Encoding}
      */
     static constructServiceData(url, advertisedTxPower) {
       // Check that it's a valid Tx Power

--- a/libraries/javascript/eddystone-advertising/lib/exports.js
+++ b/libraries/javascript/eddystone-advertising/lib/exports.js
@@ -5,6 +5,10 @@
   // the dependency graph and load all needed modules.
   let Eddystone = require('./eddystone-advertising.js');
 
-  // browserify will replace global with window.
+  /**
+   * The global eddystone instance.
+   *
+   * @global
+   */
   global.eddystone = new Eddystone();
 })();

--- a/libraries/javascript/eddystone-advertising/lib/exports.js
+++ b/libraries/javascript/eddystone-advertising/lib/exports.js
@@ -9,6 +9,7 @@
    * The global eddystone instance.
    *
    * @global
+   * @type module:eddystone-advertising
    */
   global.eddystone = new Eddystone();
 })();

--- a/libraries/javascript/eddystone-advertising/lib/platform.js
+++ b/libraries/javascript/eddystone-advertising/lib/platform.js
@@ -1,12 +1,17 @@
 (() => {
   'use strict';
+
+  /**
+   * @module platform
+   */
+
   let EddystoneChromeOS = require('./eddystone-chrome-os.js');
   /**
      Detects what API is available in the platform.
-     @private
      @returns {Object} An object that wraps the underlying BLE
      Advertising API
      @throws {Error} If the platform is unsupported
+     @alias module:platform
    */
   function platform() {
     if (typeof chrome !== 'undefined') {


### PR DESCRIPTION
Hi! I had a look at your docs, this PR contains some thoughts on how i would document this project.. 

The main change i made is to more accurately reflect the modular architecture of this library and it's core purpose - to set the `window.eddystone` global. 

You can see the rendered docs of this PR [here](https://github.com/75lb/eddystone/tree/master/libraries/javascript/eddystone-advertising). 

I also fixed a few issues
* moved `@throw` tags to correct place
* used `@todo` tag rather than `TODO:`
* removed superfluous `@class` tags (not needed when documenting a `class` statement, it's inferred)
* added `@module` tags - these **must** live at the top of the file - another jsdoc quirk
* used `@type` tag where more appropriate.. 

i'm sure you won't need all these changes, it's mainly for discussion :) 

