### PR TITLE
Allow for two custom frames.

### DIFF
--- a/protocol-specification.md
+++ b/protocol-specification.md
@@ -17,6 +17,12 @@ TLM | `0010` | `0x20`
 RESERVED | `0011` | `0x30`
 RESERVED | `0100` | `0x40`
 
+The specification allows for two custom frames that are not described in the spec and are provider specific. Because they don't have a formal specification they should always be paired with either a UID or URL frame so the receiver can identify the provider.
+
+Frame Type | High-Order 4 bits | Byte Value
+:----------|:-----------------:|:---------:
+CUSTOM | `1110` | `0xE0`
+CUSTOM | `1111` | `0xF0`
 
 The four low-order bits are reserved for future use and must be `0000`.
 


### PR DESCRIPTION
I see a need to allow for broadcasting custom data and still be within the Eddystone spec. This could easily be done by allowing for two custom frames.

But they should never be allowed to broadcast without at least a URL or UID frame, otherwise you don't have a way to detect it's an Eddystone beacon. The other reason to have the UID or URL frame is that you will only be able to decode the frame when you identified the provider.

Example, say provider X has a need to broadcast humidity and pressure, they can do this in CUSTOM frame 0. The receiver can identify the provider by URL or UID.