### PR TITLE
Fix input/output error

### DIFF
--- a/eddystone-url/implementations/linux/scan-for-urls
+++ b/eddystone-url/implementations/linux/scan-for-urls
@@ -131,9 +131,8 @@ def scan(duration = None):
     """
 
     subprocess.call(["sudo", "-v"])
-    subprocess.call("sudo hciconfig hci0 down", shell = True, stdout = subprocess.DEVNULL)
-    subprocess.call("sudo hciconfig hci0 up", shell = True, stdout = subprocess.DEVNULL)
-
+    subprocess.call("sudo hciconfig hci0 reset", shell = True, stdout = subprocess.DEVNULL)
+    
     lescan = subprocess.Popen(
             ["sudo", "-n", "hcitool", "lescan", "--duplicates"],
             stdout = subprocess.DEVNULL)

--- a/eddystone-url/implementations/linux/scan-for-urls
+++ b/eddystone-url/implementations/linux/scan-for-urls
@@ -131,6 +131,8 @@ def scan(duration = None):
     """
 
     subprocess.call(["sudo", "-v"])
+    subprocess.call("sudo hciconfig hci0 down", shell = True, stdout = subprocess.DEVNULL)
+    subprocess.call("sudo hciconfig hci0 up", shell = True, stdout = subprocess.DEVNULL)
 
     lescan = subprocess.Popen(
             ["sudo", "-n", "hcitool", "lescan", "--duplicates"],


### PR DESCRIPTION
hcitool lescan creates an error if the bluez is already running. The [solution](http://stackoverflow.com/questions/22062037/hcitool-lescan-shows-i-o-error) I found was
`hciconfig hci0 down`
`hciconfig hci0 up`

![screenshot](https://cloud.githubusercontent.com/assets/4739486/15716399/c0a95eb0-283f-11e6-8bfb-0decaf1fbb52.png)
