### PR TITLE
Replaced optparse(deprecated) to argparse

### DIFF
--- a/eddystone-url/implementations/linux/README.md
+++ b/eddystone-url/implementations/linux/README.md
@@ -2,6 +2,12 @@
 
 A set of python scripts for scanning and advertising urls over Eddystone-URL.
 
+## Requirements
+
+    Linux
+    Python 3
+    bluez
+
 ## Installation
 
     sudo apt-get install bluez
@@ -9,7 +15,7 @@ A set of python scripts for scanning and advertising urls over Eddystone-URL.
 ## Usage
 
     # Advertising a url
-    ./advertise-url http://your/url
+    ./advertise-url -u http://your/url
 
     # Stopping the advertisement
     ./advertise-url -s
@@ -21,4 +27,4 @@ A set of python scripts for scanning and advertising urls over Eddystone-URL.
     ./scan-for-urls
 
     # A continuous scan and resolving short urls to long urls
-    ./scan-for-urls | ./resolve-urls
+    ./scan-for-urls | ./resolve-urls -u [URLs]

--- a/eddystone-url/implementations/linux/advertise-url
+++ b/eddystone-url/implementations/linux/advertise-url
@@ -19,25 +19,24 @@ Advertises a url as an Eddystone beacon.
 
 import sys
 import subprocess
-from optparse import OptionParser
+import argparse
 
-parser = OptionParser(usage = "%prog [options] [url]", description = __doc__)
+# The default url
+url = "https://goo.gl/SkcDTN"
 
-parser.add_option("-s", "--stop", dest="stop",
-        action="store_true", default=False,
-        help="Stop advertising")
+parser = argparse.ArgumentParser(prog='advertise-url', description= __doc__)
+parser.add_argument("-u", "--url", nargs='?', const=url, type=str,
+    default=url, help='URL to advertise.')
 
-parser.add_option("-v", "--verbose", dest="verbose",
-        action="store_true", default=False,
-        help="Print lots of debug output")
+parser.add_argument('-s','--stop', action='store_true',
+                    help='Stop advertising url.')
 
-(options, args) = parser.parse_args()
+parser.add_argument("-v", "--verbose", action='store_true',
+                    help='Print lots of debug output.')
 
-# The default uri
-uri = "https://goo.gl/SkcDTN"
+options = parser.parse_args()
 
-if len(args) > 0:
-    uri = args[0]
+url = options.url
 
 schemes = [
         "http://www.",
@@ -57,24 +56,24 @@ def verboseOutput(text = ""):
         sys.stderr.write(text + "\n")
 
 
-def encodeUri(uri):
+def encodeurl(url):
     i = 0
     data = []
 
     for s in range(len(schemes)):
         scheme = schemes[s]
-        if uri.startswith(scheme):
+        if url.startswith(scheme):
             data.append(s)
             i += len(scheme)
             break
     else:
-        raise Exception("Invalid uri scheme")
+        raise Exception("Invalid url scheme")
 
-    while i < len(uri):
-        if uri[i] == '.':
+    while i < len(url):
+        if url[i] == '.':
             for e in range(len(extensions)):
                 expansion = extensions[e]
-                if uri.startswith(expansion, i):
+                if url.startswith(expansion, i):
                     data.append(e)
                     i += len(expansion)
                     break
@@ -82,19 +81,19 @@ def encodeUri(uri):
                 data.append(0x2E)
                 i += 1
         else:
-            data.append(ord(uri[i]))
+            data.append(ord(url[i]))
             i += 1
 
     return data
 
 
-def encodeMessage(uri):
-    encodedUri = encodeUri(uri)
-    encodedUriLength = len(encodedUri)
+def encodeMessage(url):
+    encodedurl = encodeurl(url)
+    encodedurlLength = len(encodedurl)
 
-    verboseOutput("Encoded uri length: " + str(encodedUriLength))
+    verboseOutput("Encoded url length: " + str(encodedurlLength))
 
-    if encodedUriLength > 18:
+    if encodedurlLength > 18:
         raise Exception("Encoded url too long (max 18 bytes)")
 
     message = [
@@ -107,23 +106,24 @@ def encodeMessage(uri):
             0xaa,   # 16-bit Eddystone UUID
             0xfe,   # 16-bit Eddystone UUID
 
-            5 + len(encodedUri), # Service Data length
+            5 + len(encodedurl), # Service Data length
             0x16,   # Service Data data type value
             0xaa,   # 16-bit Eddystone UUID
             0xfe,   # 16-bit Eddystone UUID
 
-            0x10,   # Eddystone-URL frame type
+            0x10,   # Eddystone-url frame type
             0xed,   # txpower
             ]
 
-    message += encodedUri
+    message += encodedurl
 
     return message
 
 
-def advertise(uri):
-    verboseOutput("Advertising: " + uri)
-    message = encodeMessage(uri)
+def advertise(url):
+    print("Advertising: " + url)
+    verboseOutput("Advertising: " + url)
+    message = encodeMessage(url)
 
     # Prepend the length of the whole message
     message.insert(0, len(message))
@@ -151,6 +151,7 @@ def advertise(uri):
 
 
 def stopAdvertising():
+    print("Stopping advertising")
     verboseOutput("Stopping advertising")
     subprocess.call("sudo hcitool -i hci0 cmd 0x08 0x000a 00", shell = True, stdout = subprocess.DEVNULL)
 
@@ -159,7 +160,7 @@ try:
     if options.stop:
         stopAdvertising()
     else:
-        advertise(uri)
+        advertise(url)
 except Exception as e:
     sys.stderr.write("Exception: " + str(e) + "\n")
     exit(1)

--- a/eddystone-url/implementations/linux/resolve-urls
+++ b/eddystone-url/implementations/linux/resolve-urls
@@ -22,11 +22,13 @@ the command line, or through standard input. Try: "./scan-for-urls |
 import http.client
 import sys
 import urllib.parse
+import argparse
 
-from optparse import OptionParser
+parser = argparse.ArgumentParser(prog='advertise-url', description= __doc__)
+parser.add_argument("-u", "--urls", nargs='+', type=str, required=True,
+    help='URLs to resolve.')
 
-parser = OptionParser(usage = "%prog [urls]", description = __doc__)
-(options, args) = parser.parse_args()
+args = parser.parse_args()
 
 
 def resolveUrl(url):
@@ -62,7 +64,7 @@ def resolveUrl(url):
 
 resolvedUrls = dict()
 
-for url in args or sys.stdin:
+for url in args.urls or sys.stdin:
     url = url.strip()
 
     if not url in resolvedUrls:

--- a/eddystone-url/implementations/linux/scan-for-urls
+++ b/eddystone-url/implementations/linux/scan-for-urls
@@ -23,19 +23,17 @@ import subprocess
 import sys
 import time
 
-from optparse import OptionParser
+import argparse
 
-parser = OptionParser(usage = "%prog [options]", description = __doc__)
+parser = argparse.ArgumentParser(prog='scan-for-urls', description= __doc__)
 
-parser.add_option("-v", "--verbose", dest = "verbose",
-        action = "store_true", default = False,
-        help = "Print lots of debug output. This mode also outputs non-url beacons.")
+parser.add_argument('-s','--single', action='store_true',
+                    help='Perform a single scan and output all the urls found without duplicates.')
 
-parser.add_option("-s", "--single", dest = "single",
-        action = "store_true", default = False,
-        help = "Perform a single scan and output all the urls found without duplicates.")
+parser.add_argument("-v", "--verbose", action='store_true',
+                    help='Print lots of debug output.')
 
-(options, args) = parser.parse_args()
+options = parser.parse_args()
 
 schemes = [
         "http://www.",


### PR DESCRIPTION
Modified README.md

optparse used in linux implementation of Eddystone URL is deprecated. Python3 uses argparse now.  #155 