### PR TITLE
Disable screen rotation (it leaks advertisers)

### DIFF
--- a/eddystone-uid/tools/txeddystone-uid/TxEddystone-UID/app/src/main/AndroidManifest.xml
+++ b/eddystone-uid/tools/txeddystone-uid/TxEddystone-UID/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
       android:theme="@style/AppTheme">
     <activity
         android:name=".MainActivity"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
 


### PR DESCRIPTION
Rotate the screen while advertising, and the advertiser leaks (when the Activity is recreated). From then on, the on/off switch is broken (you're still advertising even if you flip the switch off).  Advertising only stops if you kill the app.

So, disable screen rotation until we support this.