### PR TITLE
Fix RFC number

### DIFF
--- a/eddystone-url/README.md
+++ b/eddystone-url/README.md
@@ -72,7 +72,7 @@ below.
 |127..255 | 0x7F..0xFF | Reserved for Future Use
 
 Note: 
-* URLs are written only with the graphic printable characters of the US-ASCII coded character set. The octets **00-20** and **7F-FF** hexadecimal are not used. See “Excluded US-ASCII Characters” in RFC 2936.
+* URLs are written only with the graphic printable characters of the US-ASCII coded character set. The octets **00-20** and **7F-FF** hexadecimal are not used. See [“Excluded US-ASCII Characters” in RFC 2396](https://tools.ietf.org/html/rfc2396#section-2.4.3).
 * Range **07-13** define the same top level domains as **00-06** without a /.
 
 ## See Also


### PR DESCRIPTION
RFC 2936 is for "HTTP MIME Type Handler Detection" which does not have any section discussing "Excluded US-ASCII Characters". However, RFC 2396 (transposed 3 and 9) is for "Uniform Resource Identifiers (URI): Generic Syntax" which does section 2.4.3 discussing the aforementioned content. This also links directly to that section for ease of reference.