### PR TITLE
Add wifi:// as a URL scheme prefix

### DIFF
--- a/eddystone-url/README.md
+++ b/eddystone-url/README.md
@@ -39,6 +39,7 @@ The URL Scheme Prefix byte defines the identifier scheme, an optional prefix and
 |1        | 0x01       | `https://www.`
 |2        | 0x02       | `http://`
 |3        | 0x03       | `https://`
+|15       | 0xff       | `wifi://`
 
 ### Eddystone-URL HTTP URL encoding
 


### PR DESCRIPTION
Would be nice to have beacons advertising credentials for connecting to a public Wi-Fi network